### PR TITLE
Streamline UI startup with env config and backend integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy to .env and fill in your configuration
+GEMINI_API_KEY=your_api_key_here
+PORT=3001

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ A real-time AI assistant that provides contextual help during video calls, inter
 ## Setup
 
 1. **Get a Gemini API Key**: Visit [Google AI Studio](https://aistudio.google.com/apikey)
-2. **Install Dependencies**: `npm install`
-3. **Run the App**: `npm start`
+2. **Copy the Example Environment File**: `cp .env.example .env` and add your `GEMINI_API_KEY`
+3. **Install Dependencies**: `npm install`
+4. **Run the App**: `npm start` (starts backend and desktop client)
 
 ## Usage
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,10 +1,11 @@
+require('dotenv').config();
 const express = require('express');
-const { GoogleGenerativeAI, Modality } = require('@google/genai');
+const { GoogleGenAI, Modality } = require('@google/genai');
 const { WebSocketServer } = require('ws');
 
 const app = express();
 app.use(express.json());
-const genai = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '');
+const genai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || '' });
 
 app.post('/ask', async (req, res) => {
   const prompt = req.body.prompt || '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "GPL-3.0",
             "dependencies": {
                 "@google/genai": "^1.2.0",
+                "dotenv": "^16.4.5",
                 "electron-squirrel-startup": "^1.0.1",
                 "express": "^4.19.2",
                 "tesseract.js": "^4.0.3",
@@ -26,7 +27,18 @@
                 "@electron-forge/plugin-fuses": "^7.8.1",
                 "@electron/fuses": "^1.8.0",
                 "@reforged/maker-appimage": "^5.0.0",
+                "concurrently": "^8.2.2",
                 "electron": "^30.0.5"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+            "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@electron-forge/cli": {
@@ -2529,6 +2541,50 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/concurrently": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+            "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.2",
+                "date-fns": "^2.30.0",
+                "lodash": "^4.17.21",
+                "rxjs": "^7.8.1",
+                "shell-quote": "^1.8.1",
+                "spawn-command": "0.0.2",
+                "supports-color": "^8.1.1",
+                "tree-kill": "^1.2.2",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "conc": "dist/bin/concurrently.js",
+                "concurrently": "dist/bin/concurrently.js"
+            },
+            "engines": {
+                "node": "^14.13.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+            }
+        },
+        "node_modules/concurrently/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
         "node_modules/content-disposition": {
             "version": "0.5.4",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -2622,6 +2678,23 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.10"
+            }
+        },
+        "node_modules/date-fns": {
+            "version": "2.30.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+            "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.21.0"
+            },
+            "engines": {
+                "node": ">=0.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/date-fns"
             }
         },
         "node_modules/debug": {
@@ -2769,6 +2842,18 @@
             "dependencies": {
                 "minimatch": "^3.0.5",
                 "p-limit": "^3.1.0 "
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "16.6.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
             }
         },
         "node_modules/ds-store": {
@@ -6975,6 +7060,16 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/rxjs": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -7132,6 +7227,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/shell-quote": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/side-channel": {
@@ -7329,6 +7437,12 @@
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
+        },
+        "node_modules/spawn-command": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+            "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+            "dev": true
         },
         "node_modules/spdx-correct": {
             "version": "3.2.0",
@@ -7742,6 +7856,16 @@
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "license": "MIT"
         },
+        "node_modules/tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "tree-kill": "cli.js"
+            }
+        },
         "node_modules/trim-repeated": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -7764,6 +7888,13 @@
             "engines": {
                 "node": ">=0.8.0"
             }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/type-fest": {
             "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
     "description": "cheating daddy",
     "main": "src/index.js",
     "scripts": {
-        "start": "electron-forge start",
+        "start": "concurrently \"npm run start:backend\" \"npm run start:electron\"",
+        "start:electron": "electron-forge start",
+        "start:backend": "node backend/server.js",
         "package": "electron-forge package",
         "make": "electron-forge make",
         "publish": "electron-forge publish",
-        "lint": "echo \"No linting configured\"",
-        "start:backend": "node backend/server.js"
+        "lint": "echo \"No linting configured\""
     },
     "keywords": [
         "cheating daddy",
@@ -29,7 +30,8 @@
         "electron-squirrel-startup": "^1.0.1",
         "express": "^4.19.2",
         "tesseract.js": "^4.0.3",
-        "ws": "^8.16.0"
+        "ws": "^8.16.0",
+        "dotenv": "^16.4.5"
     },
     "devDependencies": {
         "@electron-forge/cli": "^7.8.1",
@@ -42,6 +44,7 @@
         "@electron-forge/plugin-fuses": "^7.8.1",
         "@electron/fuses": "^1.8.0",
         "@reforged/maker-appimage": "^5.0.0",
-        "electron": "^30.0.5"
+        "electron": "^30.0.5",
+        "concurrently": "^8.2.2"
     }
 }


### PR DESCRIPTION
## Summary
- load environment variables in backend and upgrade to current `@google/genai` API
- run desktop and backend together with a single `npm start`
- document required env vars via `.env.example` and updated README

## Testing
- ⚠️ `npm run lint` – No linting configured
- ❌ `npm test` – Missing script: "test"
- ✅ `cd apps/desktop && npm test`
- ✅ `cd apps/desktop && npm run lint`
- ✅ `cd apps/server && npm test`
- ✅ `cd apps/server && npm run lint`
- ⚠️ `npm start -- --no-sandbox` – electron failed to launch: `libatk-1.0.so.0` missing


------
https://chatgpt.com/codex/tasks/task_e_68b1b72d0ee88331b813cd37cd48a695