### PR TITLE
feat: add auth and cors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 # Copy to .env and fill in your configuration
 GEMINI_API_KEY=your_api_key_here
 PORT=3001
+AUTH_TOKEN=your_auth_token_here
+# Comma-separated list of allowed origins for CORS
+ALLOWED_ORIGINS=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -53,3 +53,14 @@ A real-time AI assistant that provides contextual help during video calls, inter
 - Gemini API key
 - Screen recording permissions
 - Microphone/audio permissions
+
+## Security
+
+To restrict access to the backend server:
+
+- Set `AUTH_TOKEN` in your `.env` file and provide the same value in the `x-auth-token` header when calling `/ask` or connecting to `/live`.
+  - Missing tokens result in **401 Unauthorized**.
+  - Invalid tokens result in **403 Forbidden**.
+- Use `ALLOWED_ORIGINS` to list allowed origins for CORS. Origins not in the list are blocked.
+
+These settings help ensure only trusted clients can interact with the service.

--- a/backend/__tests__/auth.test.js
+++ b/backend/__tests__/auth.test.js
@@ -1,0 +1,72 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const WebSocket = require('ws');
+const { startServer } = require('../server');
+
+test('ask endpoint enforces auth token', async (t) => {
+  process.env.AUTH_TOKEN = 'secret';
+  const server = startServer(0);
+  const port = server.address().port;
+
+  await t.test('missing token returns 401', async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/ask`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ prompt: 'hi' }),
+    });
+    assert.strictEqual(res.status, 401);
+  });
+
+  await t.test('bad token returns 403', async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/ask`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-auth-token': 'wrong',
+      },
+      body: JSON.stringify({ prompt: 'hi' }),
+    });
+    assert.strictEqual(res.status, 403);
+  });
+
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test('live websocket enforces auth token', async (t) => {
+  process.env.AUTH_TOKEN = 'secret';
+  const server = startServer(0);
+  const port = server.address().port;
+
+  await t.test('missing token denied with 401', async () => {
+    await new Promise((resolve) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/live`);
+      ws.on('open', () => {
+        ws.terminate();
+        assert.fail('should not open');
+      });
+      ws.on('error', (err) => {
+        assert.match(err.message, /401/);
+        resolve();
+      });
+    });
+  });
+
+  await t.test('bad token denied with 403', async () => {
+    await new Promise((resolve) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/live`, {
+        headers: { 'x-auth-token': 'wrong' },
+      });
+      ws.on('open', () => {
+        ws.terminate();
+        assert.fail('should not open');
+      });
+      ws.on('error', (err) => {
+        assert.match(err.message, /403/);
+        resolve();
+      });
+    });
+  });
+
+  await new Promise((resolve) => server.close(resolve));
+});
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,13 +1,47 @@
 require('dotenv').config();
 const express = require('express');
+const cors = require('cors');
 const { GoogleGenAI, Modality } = require('@google/genai');
 const { WebSocketServer } = require('ws');
 
 const app = express();
 app.use(express.json());
+
+// Configure CORS with allowed origins list
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((o) => o.trim())
+  .filter(Boolean);
+
+app.use(
+  cors({
+    origin: (origin, cb) => {
+      if (!origin || allowedOrigins.length === 0 || allowedOrigins.includes(origin)) {
+        cb(null, true);
+      } else {
+        cb(new Error('Not allowed by CORS'));
+      }
+    },
+  })
+);
+
 const genai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || '' });
 
-app.post('/ask', async (req, res) => {
+// Optional auth middleware
+function checkAuth(req, res, next) {
+  const expected = process.env.AUTH_TOKEN;
+  if (!expected) return next();
+  const token = req.headers['x-auth-token'];
+  if (!token) {
+    return res.status(401).json({ error: 'Auth token required' });
+  }
+  if (token !== expected) {
+    return res.status(403).json({ error: 'Invalid auth token' });
+  }
+  next();
+}
+
+app.post('/ask', checkAuth, async (req, res) => {
   const prompt = req.body.prompt || '';
   try {
     const model = genai.getGenerativeModel({ model: 'gemini-pro' });
@@ -20,33 +54,65 @@ app.post('/ask', async (req, res) => {
   }
 });
 
-const server = app.listen(process.env.PORT || 3001);
+function startServer(port = process.env.PORT || 3001) {
+  const server = app.listen(port);
 
-// WebSocket endpoint for Gemini Live
-const wss = new WebSocketServer({ server, path: '/live' });
-wss.on('connection', async (ws) => {
-  const session = await genai.live.connect({
-    model: 'gemini-live-2.5-flash-preview',
-    config: { response_modalities: [Modality.TEXT], system_instruction: 'You are a helpful assistant.' }
+  // WebSocket endpoint for Gemini Live
+  const wss = new WebSocketServer({
+    server,
+    path: '/live',
+    verifyClient: (info, done) => {
+      if (allowedOrigins.length && info.origin && !allowedOrigins.includes(info.origin)) {
+        return done(false, 403, 'Origin not allowed');
+      }
+      const expected = process.env.AUTH_TOKEN;
+      if (!expected) return done(true);
+      const token = info.req.headers['x-auth-token'];
+      if (!token) return done(false, 401, 'Auth token required');
+      if (token !== expected) return done(false, 403, 'Invalid auth token');
+      return done(true);
+    },
   });
 
-  // Forward Gemini replies back to the client
-  (async () => {
-    for await (const response of session.receive()) {
-      ws.send(JSON.stringify({ text: response.text || '' }));
-    }
-  })();
+  wss.on('connection', async (ws) => {
+    const session = await genai.live.connect({
+      model: 'gemini-live-2.5-flash-preview',
+      config: {
+        response_modalities: [Modality.TEXT],
+        system_instruction: 'You are a helpful assistant.',
+      },
+    });
 
-  ws.on('message', async (msg) => {
-    const data = JSON.parse(msg);
-    if (data.audio) {
-      const buf = Buffer.from(data.audio, 'base64');
-      await session.send_realtime_input({ audio: { data: buf, mime_type: data.mimeType || 'audio/pcm;rate=16000' } });
-    } else if (data.image) {
-      const buf = Buffer.from(data.image, 'base64');
-      await session.send_realtime_input({ image: { data: buf, mime_type: data.mimeType || 'image/jpeg' } });
-    }
+    // Forward Gemini replies back to the client
+    (async () => {
+      for await (const response of session.receive()) {
+        ws.send(JSON.stringify({ text: response.text || '' }));
+      }
+    })();
+
+    ws.on('message', async (msg) => {
+      const data = JSON.parse(msg);
+      if (data.audio) {
+        const buf = Buffer.from(data.audio, 'base64');
+        await session.send_realtime_input({
+          audio: { data: buf, mime_type: data.mimeType || 'audio/pcm;rate=16000' },
+        });
+      } else if (data.image) {
+        const buf = Buffer.from(data.image, 'base64');
+        await session.send_realtime_input({
+          image: { data: buf, mime_type: data.mimeType || 'image/jpeg' },
+        });
+      }
+    });
+
+    ws.on('close', () => session.close());
   });
 
-  ws.on('close', () => session.close());
-});
+  return server;
+}
+
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = { app, startServer };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@google/genai": "^1.2.0",
+        "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "electron-squirrel-startup": "^1.0.1",
         "express": "^4.19.2",
@@ -2837,7 +2838,6 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -6702,7 +6702,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "make": "electron-forge make",
     "publish": "electron-forge publish",
     "lint": "eslint .",
-    "test": "node --test src/utils/__tests__/*.test.js",
+    "test": "node --test src/utils/__tests__/*.test.js backend/__tests__/*.test.js",
     "format": "prettier --write ."
   },
   "keywords": [
@@ -29,6 +29,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@google/genai": "^1.2.0",
+    "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "electron-squirrel-startup": "^1.0.1",
     "express": "^4.19.2",


### PR DESCRIPTION
## Summary
- secure `/ask` and `/live` with optional auth token and CORS restrictions
- document server security options and environment variables
- add tests for unauthorized access

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4cd090ce08331a1e9c17091086e5b