### PR TITLE
Improve SystemAudioDump handling and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A real-time AI assistant that provides contextual help during video calls, inter
 
 ## Audio Capture
 
-- **macOS**: [SystemAudioDump](https://github.com/Mohammed-Yasin-Mulla/Sound) for system audio
+- **macOS**: [SystemAudioDump](https://github.com/Mohammed-Yasin-Mulla/Sound) for system audio. During development place the compiled `SystemAudioDump` binary in `src/assets/SystemAudioDump`. For packaged builds the binary must reside in the app's `resources` directory.
 - **Windows**: Loopback audio capture
 - **Linux**: Microphone input
 

--- a/src/utils/__tests__/audioHandler.test.js
+++ b/src/utils/__tests__/audioHandler.test.js
@@ -1,8 +1,8 @@
-const { test } = require('node:test');
+const { test, mock } = require('node:test');
 const assert = require('node:assert');
-const { convertStereoToMono, computeEnergyFromBase64Pcm16 } = require('../audioHandler');
 
 test('convertStereoToMono converts buffer', () => {
+    const { convertStereoToMono } = require('../audioHandler');
     const stereo = Buffer.alloc(8);
     stereo.writeInt16LE(1, 0);
     stereo.writeInt16LE(2, 2);
@@ -15,6 +15,7 @@ test('convertStereoToMono converts buffer', () => {
 });
 
 test('computeEnergyFromBase64Pcm16 calculates average amplitude', () => {
+    const { computeEnergyFromBase64Pcm16 } = require('../audioHandler');
     const buf = Buffer.alloc(4);
     buf.writeInt16LE(1000, 0);
     buf.writeInt16LE(-1000, 2);
@@ -22,3 +23,98 @@ test('computeEnergyFromBase64Pcm16 calculates average amplitude', () => {
     const energy = computeEnergyFromBase64Pcm16(base64);
     assert.strictEqual(energy, 1000);
 });
+
+test('startMacOSAudioCapture rejects if binary missing', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    const fs = require('fs');
+    const cp = require('child_process');
+    mock.method(cp, 'exec', (cmd, cb) => cb(null, ''));
+    mock.method(fs, 'existsSync', () => false);
+
+    const electronPath = require.resolve('electron');
+    require.cache[electronPath] = { exports: { app: { isPackaged: false } } };
+
+    const modulePath = require.resolve('../audioHandler');
+    delete require.cache[modulePath];
+    const { startMacOSAudioCapture } = require(modulePath);
+
+    await assert.rejects(() => startMacOSAudioCapture({ current: null }), /SystemAudioDump binary not found/);
+
+    mock.restoreAll();
+    delete require.cache[modulePath];
+    delete require.cache[electronPath];
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+});
+
+test('startMacOSAudioCapture propagates spawn error', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    const fs = require('fs');
+    const cp = require('child_process');
+    mock.method(cp, 'exec', (cmd, cb) => cb(null, ''));
+    mock.method(fs, 'existsSync', () => true);
+
+    const electronPath = require.resolve('electron');
+    require.cache[electronPath] = { exports: { app: { isPackaged: false } } };
+
+    mock.method(cp, 'spawn', () => {
+        const { EventEmitter } = require('events');
+        const proc = new EventEmitter();
+        proc.pid = 1234;
+        proc.stdout = new EventEmitter();
+        proc.stderr = new EventEmitter();
+        proc.kill = () => {};
+        process.nextTick(() => proc.emit('error', new Error('spawn fail')));
+        return proc;
+    });
+
+    const modulePath = require.resolve('../audioHandler');
+    delete require.cache[modulePath];
+    const { startMacOSAudioCapture } = require(modulePath);
+
+    await assert.rejects(() => startMacOSAudioCapture({ current: null }), /spawn fail/);
+
+    mock.restoreAll();
+    delete require.cache[modulePath];
+    delete require.cache[electronPath];
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+});
+
+test('startMacOSAudioCapture propagates stderr output', async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    const fs = require('fs');
+    const cp = require('child_process');
+    mock.method(cp, 'exec', (cmd, cb) => cb(null, ''));
+    mock.method(fs, 'existsSync', () => true);
+
+    const electronPath = require.resolve('electron');
+    require.cache[electronPath] = { exports: { app: { isPackaged: false } } };
+
+    mock.method(cp, 'spawn', () => {
+        const { EventEmitter } = require('events');
+        const proc = new EventEmitter();
+        proc.pid = 1234;
+        proc.stdout = new EventEmitter();
+        proc.stderr = new EventEmitter();
+        proc.kill = () => {};
+        process.nextTick(() => proc.stderr.emit('data', Buffer.from('boom')));
+        return proc;
+    });
+
+    const modulePath = require.resolve('../audioHandler');
+    delete require.cache[modulePath];
+    const { startMacOSAudioCapture } = require(modulePath);
+
+    await assert.rejects(() => startMacOSAudioCapture({ current: null }), /SystemAudioDump stderr: boom/);
+
+    mock.restoreAll();
+    delete require.cache[modulePath];
+    delete require.cache[electronPath];
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+});
+


### PR DESCRIPTION
## Summary
- Verify SystemAudioDump binary exists before starting and stop lingering processes via Node
- Propagate spawn and stderr errors for macOS audio capture
- Document SystemAudioDump binary location requirements
- Add tests for missing binary, spawn errors, and stderr output

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4cd0e7d1c8331b6c40d7545b1acc1