### PR TITLE
docs: rebrand service headers to Sales Wizard

### DIFF
--- a/src/services/audio.js
+++ b/src/services/audio.js
@@ -1,5 +1,5 @@
 /**
- * Audio transcription service for Cheating Daddy.
+ * Audio transcription service for Sales Wizard.
  * Uses the Web Speech API when available, otherwise records a short
  * snippet from the microphone and sends it to either a local model or
  * the Gemini API for transcription.

--- a/src/services/ocr.js
+++ b/src/services/ocr.js
@@ -1,5 +1,5 @@
 /**
- * OCR service for Cheating Daddy.
+ * OCR service for Sales Wizard.
  * Accepts a base64-encoded PNG and returns recognized text using Tesseract.js.
  */
 export async function ocrBase64(base64) {

--- a/src/utils/voiceAssistant.js
+++ b/src/utils/voiceAssistant.js
@@ -1,5 +1,5 @@
 /*
- * Voice assistant helper for Cheating Daddy.
+ * Voice assistant helper for Sales Wizard.
  *
  * This module provides a simple wrapper around the browser's Web Speech
  * API (SpeechRecognition) to continuously listen for speech, convert it


### PR DESCRIPTION
## Summary
- update voice assistant helper header for Sales Wizard
- rename audio transcription service docs to Sales Wizard
- clarify OCR service header for Sales Wizard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bae18410408331818b75af5c079653