### PR TITLE
feat: add history and context IPC channels

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -9,4 +9,14 @@ const ipc = {
     removeAllListeners: channel => ipcRenderer.removeAllListeners(channel),
 };
 
-contextBridge.exposeInMainWorld('electron', { ipcRenderer: ipc });
+contextBridge.exposeInMainWorld('electron', {
+    ipcRenderer: ipc,
+    history: {
+        list: () => ipcRenderer.invoke('history:list'),
+        get: id => ipcRenderer.invoke('history:get', id),
+    },
+    context: {
+        get: () => ipcRenderer.invoke('context:get'),
+        set: value => ipcRenderer.invoke('context:set', value),
+    },
+});


### PR DESCRIPTION
## Summary
- expose `history:list`, `history:get`, `context:get`, and `context:set` in the main process
- bridge new history and context helpers via `preload.js`
- use IPC-backed helpers in renderer for history queries and user context

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb14b6805c8331ab865b5906af21f5