### PR TITLE
refactor: introduce secure ipc renderer api

### DIFF
--- a/src/components/views/AdvancedView.js
+++ b/src/components/views/AdvancedView.js
@@ -399,9 +399,8 @@ export class AdvancedView extends LitElement {
                 this.requestUpdate();
                 setTimeout(async () => {
                     // Close the entire application
-                    if (window.electron?.ipcRenderer) {
-                        const { ipcRenderer } = window.electron;
-                        await ipcRenderer.invoke('quit-application');
+                    if (window.electron?.quitApplication) {
+                        await window.electron.quitApplication();
                     }
                 }, 1000);
             }, 2000);
@@ -477,10 +476,9 @@ export class AdvancedView extends LitElement {
         localStorage.setItem('contentProtection', this.contentProtection.toString());
         
         // Update the window's content protection in real-time
-        if (window.electron?.ipcRenderer) {
-            const { ipcRenderer } = window.electron;
+        if (window.electron?.updateContentProtection) {
             try {
-                await ipcRenderer.invoke('update-content-protection', this.contentProtection);
+                await window.electron.updateContentProtection(this.contentProtection);
             } catch (error) {
                 logger.error('Failed to update content protection:', error);
             }

--- a/src/components/views/AssistantView.js
+++ b/src/components/views/AssistantView.js
@@ -445,9 +445,7 @@ export class AssistantView extends LitElement {
         this.loadFontSize();
 
         // Set up IPC listeners for keyboard shortcuts
-        if (window.electron?.ipcRenderer) {
-            const { ipcRenderer } = window.electron;
-
+        if (window.electron) {
             this.handlePreviousResponse = () => {
                 logger.info('Received navigate-previous-response message');
                 this.navigateToPreviousResponse();
@@ -468,10 +466,10 @@ export class AssistantView extends LitElement {
                 this.scrollResponseDown();
             };
 
-            ipcRenderer.on('navigate-previous-response', this.handlePreviousResponse);
-            ipcRenderer.on('navigate-next-response', this.handleNextResponse);
-            ipcRenderer.on('scroll-response-up', this.handleScrollUp);
-            ipcRenderer.on('scroll-response-down', this.handleScrollDown);
+            window.electron.onNavigatePreviousResponse?.(this.handlePreviousResponse);
+            window.electron.onNavigateNextResponse?.(this.handleNextResponse);
+            window.electron.onScrollResponseUp?.(this.handleScrollUp);
+            window.electron.onScrollResponseDown?.(this.handleScrollDown);
         }
     }
 
@@ -479,19 +477,18 @@ export class AssistantView extends LitElement {
         super.disconnectedCallback();
 
         // Clean up IPC listeners
-        if (window.electron?.ipcRenderer) {
-            const { ipcRenderer } = window.electron;
+        if (window.electron) {
             if (this.handlePreviousResponse) {
-                ipcRenderer.removeListener('navigate-previous-response', this.handlePreviousResponse);
+                window.electron.removeNavigatePreviousResponse?.(this.handlePreviousResponse);
             }
             if (this.handleNextResponse) {
-                ipcRenderer.removeListener('navigate-next-response', this.handleNextResponse);
+                window.electron.removeNavigateNextResponse?.(this.handleNextResponse);
             }
             if (this.handleScrollUp) {
-                ipcRenderer.removeListener('scroll-response-up', this.handleScrollUp);
+                window.electron.removeScrollResponseUp?.(this.handleScrollUp);
             }
             if (this.handleScrollDown) {
-                ipcRenderer.removeListener('scroll-response-down', this.handleScrollDown);
+                window.electron.removeScrollResponseDown?.(this.handleScrollDown);
             }
         }
     }

--- a/src/components/views/CustomizeView.js
+++ b/src/components/views/CustomizeView.js
@@ -573,7 +573,7 @@ export class CustomizeView extends LitElement {
 
     updateContextParams() {
         try {
-            window.electron?.ipcRenderer?.invoke('set-context-params', {
+            window.electron?.setContextParams?.({
                 allowedSources: this.allowedSources,
                 toneLength: this.toneLength,
                 disallowedTopics: this.disallowedTopics,
@@ -656,9 +656,8 @@ export class CustomizeView extends LitElement {
     saveKeybinds() {
         localStorage.setItem('customKeybinds', JSON.stringify(this.keybinds));
         // Send to main process to update global shortcuts
-        if (window.electron?.ipcRenderer) {
-            const { ipcRenderer } = window.electron;
-            ipcRenderer.send('update-keybinds', this.keybinds);
+        if (window.electron?.updateKeybinds) {
+            window.electron.updateKeybinds(this.keybinds);
         }
     }
 
@@ -672,9 +671,8 @@ export class CustomizeView extends LitElement {
         this.keybinds = this.getDefaultKeybinds();
         localStorage.removeItem('customKeybinds');
         this.requestUpdate();
-        if (window.electron?.ipcRenderer) {
-            const { ipcRenderer } = window.electron;
-            ipcRenderer.send('update-keybinds', this.keybinds);
+        if (window.electron?.updateKeybinds) {
+            window.electron.updateKeybinds(this.keybinds);
         }
     }
 
@@ -834,10 +832,9 @@ export class CustomizeView extends LitElement {
         localStorage.setItem('googleSearchEnabled', this.googleSearchEnabled.toString());
 
         // Notify main process if available
-        if (window.electron?.ipcRenderer) {
+        if (window.electron?.updateGoogleSearchSetting) {
             try {
-                const { ipcRenderer } = window.electron;
-                await ipcRenderer.invoke('update-google-search-setting', this.googleSearchEnabled);
+                await window.electron.updateGoogleSearchSetting(this.googleSearchEnabled);
             } catch (error) {
                 logger.error('Failed to notify main process:', error);
             }

--- a/src/components/views/MainView.js
+++ b/src/components/views/MainView.js
@@ -163,7 +163,7 @@ export class MainView extends LitElement {
 
     connectedCallback() {
         super.connectedCallback();
-        window.electron?.ipcRenderer?.on('session-initializing', (event, isInitializing) => {
+        window.electron?.onSessionInitializing?.((event, isInitializing) => {
             this.isInitializing = isInitializing;
         });
 
@@ -178,7 +178,7 @@ export class MainView extends LitElement {
 
     disconnectedCallback() {
         super.disconnectedCallback();
-        window.electron?.ipcRenderer?.removeAllListeners('session-initializing');
+        window.electron?.removeSessionInitializingListeners?.();
         // Remove keyboard event listener
         document.removeEventListener('keydown', this.boundKeydownHandler);
     }
@@ -197,9 +197,8 @@ export class MainView extends LitElement {
         const value = e.target.value;
         // Prefer secure store via IPC, fallback to localStorage
         try {
-            const { ipcRenderer } = window.require?.('electron') || {};
-            if (ipcRenderer) {
-                await ipcRenderer.invoke('secure-set-api-key', value);
+            if (window.electron?.secureSetApiKey) {
+                await window.electron.secureSetApiKey(value);
             } else {
                 localStorage.setItem('apiKey', value);
             }
@@ -214,9 +213,8 @@ export class MainView extends LitElement {
 
     async firstUpdated() {
         try {
-            const { ipcRenderer } = window.require?.('electron') || {};
-            if (ipcRenderer) {
-                const res = await ipcRenderer.invoke('secure-get-api-key');
+            if (window.electron?.secureGetApiKey) {
+                const res = await window.electron.secureGetApiKey();
                 if (res?.success && res.value) {
                     const input = this.renderRoot?.querySelector('input[type="password"]');
                     if (input) input.value = res.value;

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,12 +1,62 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
-const ipc = {
-    invoke: (channel, ...args) => ipcRenderer.invoke(channel, ...args),
-    send: (channel, ...args) => ipcRenderer.send(channel, ...args),
-    on: (channel, listener) => ipcRenderer.on(channel, listener),
-    once: (channel, listener) => ipcRenderer.once(channel, listener),
-    removeListener: (channel, listener) => ipcRenderer.removeListener(channel, listener),
-    removeAllListeners: channel => ipcRenderer.removeAllListeners(channel),
+const api = {
+  updateSizes: () => ipcRenderer.invoke('update-sizes'),
+  getCursorPoint: () => ipcRenderer.invoke('get-cursor-point'),
+  secureGetApiKey: () => ipcRenderer.invoke('secure-get-api-key'),
+  secureSetApiKey: value => ipcRenderer.invoke('secure-set-api-key', value),
+  initializeGemini: (apiKey, prompt, profile, language) =>
+    ipcRenderer.invoke('initialize-gemini', apiKey, prompt, profile, language),
+  startMacosAudio: () => ipcRenderer.invoke('start-macos-audio'),
+  stopMacosAudio: () => ipcRenderer.invoke('stop-macos-audio'),
+  sendImageContent: payload => ipcRenderer.invoke('send-image-content', payload),
+  sendAudioContent: payload => ipcRenderer.invoke('send-audio-content', payload),
+  sendTextMessage: text => ipcRenderer.invoke('send-text-message', text),
+  closeSession: () => ipcRenderer.invoke('close-session'),
+  quitApplication: () => ipcRenderer.invoke('quit-application'),
+  toggleWindowVisibility: () => ipcRenderer.invoke('toggle-window-visibility'),
+  openExternal: url => ipcRenderer.invoke('open-external', url),
+  viewChanged: view => ipcRenderer.send('view-changed', view),
+  updateKeybinds: keybinds => ipcRenderer.send('update-keybinds', keybinds),
+  setContextParams: params => ipcRenderer.invoke('set-context-params', params),
+  updateGoogleSearchSetting: enabled =>
+    ipcRenderer.invoke('update-google-search-setting', enabled),
+  updateContentProtection: enabled =>
+    ipcRenderer.invoke('update-content-protection', enabled),
+  getRandomDisplayName: () => ipcRenderer.invoke('get-random-display-name'),
+  onUpdateResponse: handler => ipcRenderer.on('update-response', handler),
+  removeUpdateResponseListener: handler =>
+    ipcRenderer.removeListener('update-response', handler),
+  onUpdateStatus: handler => ipcRenderer.on('update-status', handler),
+  removeUpdateStatusListener: handler =>
+    ipcRenderer.removeListener('update-status', handler),
+  onClickThroughToggled: handler =>
+    ipcRenderer.on('click-through-toggled', handler),
+  removeClickThroughToggledListener: handler =>
+    ipcRenderer.removeListener('click-through-toggled', handler),
+  onSessionInitializing: handler =>
+    ipcRenderer.on('session-initializing', handler),
+  removeSessionInitializingListeners: () =>
+    ipcRenderer.removeAllListeners('session-initializing'),
+  onNavigatePreviousResponse: handler =>
+    ipcRenderer.on('navigate-previous-response', handler),
+  removeNavigatePreviousResponse: handler =>
+    ipcRenderer.removeListener('navigate-previous-response', handler),
+  onNavigateNextResponse: handler =>
+    ipcRenderer.on('navigate-next-response', handler),
+  removeNavigateNextResponse: handler =>
+    ipcRenderer.removeListener('navigate-next-response', handler),
+  onScrollResponseUp: handler => ipcRenderer.on('scroll-response-up', handler),
+  removeScrollResponseUp: handler =>
+    ipcRenderer.removeListener('scroll-response-up', handler),
+  onScrollResponseDown: handler =>
+    ipcRenderer.on('scroll-response-down', handler),
+  removeScrollResponseDown: handler =>
+    ipcRenderer.removeListener('scroll-response-down', handler),
+  onSaveConversationTurn: handler =>
+    ipcRenderer.on('save-conversation-turn', handler),
+  removeSaveConversationTurnListener: handler =>
+    ipcRenderer.removeListener('save-conversation-turn', handler)
 };
 
-contextBridge.exposeInMainWorld('electron', { ipcRenderer: ipc });
+contextBridge.exposeInMainWorld('electron', api);

--- a/src/utils/screenCapture.js
+++ b/src/utils/screenCapture.js
@@ -3,10 +3,10 @@ export async function startScreenCapture({ intervalMs = 1000, quality = 'medium'
   let lastCursorPoint = null;
 
   function startCursorTracking() {
-    if (!window.electron?.ipcRenderer) return;
+    if (!window.electron?.getCursorPoint) return;
     const poll = async () => {
       try {
-        const res = await window.electron.ipcRenderer.invoke('get-cursor-point');
+        const res = await window.electron.getCursorPoint();
         if (res?.success) lastCursorPoint = res;
       } catch (_e) {
         /* ignore */

--- a/src/utils/windowResize.js
+++ b/src/utils/windowResize.js
@@ -1,8 +1,7 @@
 export async function resizeLayout() {
     try {
-        if (window.electron?.ipcRenderer) {
-            const { ipcRenderer } = window.electron;
-            const result = await ipcRenderer.invoke('update-sizes');
+        if (window.electron?.updateSizes) {
+            const result = await window.electron.updateSizes();
             if (result.success) {
                 logger.info('Window resized for current view');
             } else {


### PR DESCRIPTION
## Summary
- replace blanket `ipcRenderer` exposure with an explicit preload API
- update renderer views to call new IPC helpers instead of raw channels
- ensure Electron runs with `contextIsolation: true`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb4c8f05908331b4eafacf018a6600