### PR TITLE
feat: add session export with notes

### DIFF
--- a/src/components/app/CheatingDaddyApp.js
+++ b/src/components/app/CheatingDaddyApp.js
@@ -600,6 +600,7 @@ export class CheatingDaddyApp extends LitElement {
                         <side-panel
                             .notes=${this.notes}
                             .transcripts=${this.transcripts}
+                            .selectedProfile=${this.selectedProfile}
                             @notes-change=${e => this.handleNotesChange(e)}
                         ></side-panel>
                     </div>

--- a/src/preload.js
+++ b/src/preload.js
@@ -24,6 +24,7 @@ const api = {
   updateContentProtection: enabled =>
     ipcRenderer.invoke('update-content-protection', enabled),
   getRandomDisplayName: () => ipcRenderer.invoke('get-random-display-name'),
+  exportSession: options => ipcRenderer.invoke('export-session', options),
   onUpdateResponse: handler => ipcRenderer.on('update-response', handler),
   removeUpdateResponseListener: handler =>
     ipcRenderer.removeListener('update-response', handler),

--- a/src/utils/__tests__/sessionManager.test.js
+++ b/src/utils/__tests__/sessionManager.test.js
@@ -14,3 +14,49 @@ test('getEnabledTools respects googleSearch setting', async () => {
     assert.deepStrictEqual(tools, []);
     sessionManager.getStoredSetting = original;
 });
+
+test('exportSession generates JSON blob with metadata', async () => {
+    const { blob, filename } = sessionManager.exportSession({
+        format: 'json',
+        session: {
+            sessionId: 'abc',
+            history: [
+                {
+                    timestamp: 0,
+                    transcription: 'hello',
+                    ai_response: 'hi',
+                },
+            ],
+        },
+        notes: 'some notes',
+        profile: 'interview',
+    });
+    assert.strictEqual(filename, 'session-abc.json');
+    const text = await blob.text();
+    const data = JSON.parse(text);
+    assert.strictEqual(data.notes, 'some notes');
+    assert.strictEqual(data.metadata.profile, 'interview');
+    assert.strictEqual(data.conversation.length, 1);
+});
+
+test('exportSession generates Markdown blob', async () => {
+    const { blob } = sessionManager.exportSession({
+        format: 'markdown',
+        session: {
+            sessionId: 'abc',
+            history: [
+                {
+                    timestamp: 0,
+                    transcription: 'hello',
+                    ai_response: 'hi',
+                },
+            ],
+        },
+        notes: 'note',
+        profile: 'interview',
+    });
+    const text = await blob.text();
+    assert.ok(text.includes('# Session abc'));
+    assert.ok(text.includes('note'));
+    assert.ok(text.includes('hello'));
+});

--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -98,6 +98,22 @@ function setupGeminiIpcHandlers(geminiSessionRef) {
         }
     });
 
+    ipcMain.handle('export-session', async options => {
+        try {
+            const { blob, filename } = sessionManager.exportSession(options);
+            const buffer = Buffer.from(await blob.arrayBuffer());
+            return {
+                success: true,
+                data: buffer.toString('base64'),
+                mimeType: blob.type,
+                filename,
+            };
+        } catch (error) {
+            logger.error('Error exporting session:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
     ipcMain.handle('update-google-search-setting', async enabled => {
         try {
             logger.info('Google Search setting updated to:', enabled);


### PR DESCRIPTION
## Summary
- support exporting session transcripts and notes to JSON or Markdown with metadata
- add Save session button with format selector in SidePanel and History view
- expose IPC export-session handler and tests for session export

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcee46cc44833186899fd88cb5f9e5