### PR TITLE
Add real-time audio level indicator

### DIFF
--- a/src/components/app/AppHeader.js
+++ b/src/components/app/AppHeader.js
@@ -1,5 +1,6 @@
 import { html, css, LitElement } from '../../assets/lit-core-2.7.4.min.js';
 import { getAppName } from '../../utils/config.js';
+import './AudioLevelIndicator.js';
 
 export class AppHeader extends LitElement {
     static styles = css`
@@ -103,6 +104,7 @@ export class AppHeader extends LitElement {
         advancedMode: { type: Boolean },
         onAdvancedClick: { type: Function },
         appName: { type: String },
+        audioLevel: { type: Number },
     };
 
     constructor() {
@@ -121,6 +123,7 @@ export class AppHeader extends LitElement {
         this.onAdvancedClick = () => {};
         this.appName = getAppName();
         this._timerInterval = null;
+        this.audioLevel = 0;
         this._appNameInterval = null;
     }
 
@@ -384,6 +387,7 @@ export class AppHeader extends LitElement {
                         : ''}
                     ${this.currentView === 'assistant'
                         ? html`
+                              <audio-level-indicator .level=${this.audioLevel}></audio-level-indicator>
                               <button @click=${this.onHideToggleClick} class="button">
                                   Hide&nbsp;&nbsp;<span class="key" style="pointer-events: none;">${cheddar.isMacOS ? 'Cmd' : 'Ctrl'}</span
                                   >&nbsp;&nbsp;<span class="key">&bsol;</span>

--- a/src/components/app/AudioLevelIndicator.js
+++ b/src/components/app/AudioLevelIndicator.js
@@ -1,0 +1,38 @@
+import { html, css, LitElement } from '../../assets/lit-core-2.7.4.min.js';
+
+export class AudioLevelIndicator extends LitElement {
+    static properties = {
+        level: { type: Number }
+    };
+
+    constructor() {
+        super();
+        this.level = 0;
+    }
+
+    static styles = css`
+        :host {
+            display: block;
+        }
+        .meter {
+            width: 40px;
+            height: 8px;
+            background: var(--input-background);
+            border-radius: 4px;
+            overflow: hidden;
+        }
+        .level {
+            height: 100%;
+            background: var(--focus-border-color);
+            width: 0%;
+            transition: width 0.1s linear;
+        }
+    `;
+
+    render() {
+        const pct = Math.min(1, Math.max(0, this.level)) * 100;
+        return html`<div class="meter"><div class="level" style="width:${pct}%"></div></div>`;
+    }
+}
+
+customElements.define('audio-level-indicator', AudioLevelIndicator);

--- a/src/components/app/CheatingDaddyApp.js
+++ b/src/components/app/CheatingDaddyApp.js
@@ -145,6 +145,7 @@ export class CheatingDaddyApp extends LitElement {
         _isClickThrough: { state: true },
         _awaitingNewResponse: { state: true },
         shouldAnimateResponse: { type: Boolean },
+        audioLevel: { type: Number },
     };
 
     constructor() {
@@ -170,6 +171,7 @@ export class CheatingDaddyApp extends LitElement {
         this.sessionId = null;
         this.transcripts = [];
         this.notes = '';
+        this.audioLevel = 0;
 
         // Apply layout mode to document root
         this.updateLayoutMode();
@@ -246,6 +248,10 @@ export class CheatingDaddyApp extends LitElement {
             },
             onStatus: status => this.setStatus(status),
             onError: err => logger.error('Live streaming error:', err),
+            onAudioLevel: level => {
+                this.audioLevel = level;
+                this.requestUpdate();
+            },
         })
             .then(stopFn => {
                 this._stopLiveStreaming = stopFn;
@@ -624,6 +630,7 @@ export class CheatingDaddyApp extends LitElement {
                         .statusText=${this.statusText}
                         .startTime=${this.startTime}
                         .advancedMode=${this.advancedMode}
+                        .audioLevel=${this.audioLevel}
                         .onCustomizeClick=${() => this.handleCustomizeClick()}
                         .onHelpClick=${() => this.handleHelpClick()}
                         .onHistoryClick=${() => this.handleHistoryClick()}


### PR DESCRIPTION
## Summary
- Display live microphone level via new `AudioLevelIndicator` component in the header
- Stream audio levels from `liveStreamer` to the UI for real-time feedback
- Track and pass audio level state through `CheatingDaddyApp` and render in `AppHeader`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdf9fb46b88331ac2caea44247947f