### PR TITLE
Add robust logger fallback to streaming and app components

### DIFF
--- a/src/components/app/CheatingDaddyApp.js
+++ b/src/components/app/CheatingDaddyApp.js
@@ -14,6 +14,10 @@ import '../views/SidePanel.js';
 import { startListening } from '../../utils/voiceAssistant.js';
 // Live streaming helper integrates with Gemini Live via backend
 import { startLiveStreaming } from '../../utils/liveStreamer.js';
+import { logger as defaultLogger } from '../../utils/logger.js';
+
+// Use global logger if available, falling back to the imported logger or console
+const logger = globalThis.logger || defaultLogger || console;
 
 export class CheatingDaddyApp extends LitElement {
     static styles = css`

--- a/src/utils/liveStreamer.js
+++ b/src/utils/liveStreamer.js
@@ -1,4 +1,8 @@
 import { LLMClient } from '../services/llmClient.js';
+import { logger as defaultLogger } from './logger.js';
+
+// Fallback to console if the logger script fails to attach to globalThis
+const logger = globalThis.logger || defaultLogger || console;
 
 /**
  * Starts streaming microphone audio and screen captures to the backend


### PR DESCRIPTION
## Summary
- Import logger utility in `liveStreamer` and `CheatingDaddyApp`
- Guard logger usage with `globalThis.logger || console` fallback to avoid crashes when logger fails to load

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcee50fd2c83319323a2bfc23735a8