### PR TITLE
feat: add note stream panel component

### DIFF
--- a/src/components/app/NoteStreamPanel.js
+++ b/src/components/app/NoteStreamPanel.js
@@ -1,0 +1,57 @@
+import { html, css, LitElement } from '../../assets/lit-core-2.7.4.min.js';
+
+export class NoteStreamPanel extends LitElement {
+    static properties = {
+        notes: { type: Array },
+    };
+
+    constructor() {
+        super();
+        this.notes = [];
+    }
+
+    static styles = css`
+        :host {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+            background: var(--main-content-background);
+            color: var(--text-color);
+            border-left: 1px solid var(--border-color);
+        }
+
+        .notes {
+            flex: 1;
+            overflow-y: auto;
+            padding: var(--main-content-padding);
+        }
+
+        .note-item {
+            padding: 4px 0;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .note-item:last-child {
+            border-bottom: none;
+        }
+    `;
+
+    addNote(note) {
+        this.notes = [...this.notes, note];
+    }
+
+    clear() {
+        this.notes = [];
+    }
+
+    render() {
+        /* prettier-ignore */
+        return html`
+            <div class="notes">
+                ${this.notes.map(note => html`<div class="note-item">${note}</div>`)}
+            </div>
+        `;
+    }
+}
+
+customElements.define('note-stream-panel', NoteStreamPanel);

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,6 +2,7 @@
 export { CheatingDaddyApp } from './app/CheatingDaddyApp.js';
 export { AppHeader } from './app/AppHeader.js';
 export { SidePanel } from './app/SidePanel.js';
+export { NoteStreamPanel } from './app/NoteStreamPanel.js';
 
 // View components
 export { MainView } from './views/MainView.js';


### PR DESCRIPTION
## Summary
- add NoteStreamPanel LitElement component for displaying streamed notes
- expose NoteStreamPanel via components index

## Testing
- `npm test` *(fails: /workspace/Sales-Wizard/src/utils/__tests__/liveStreamer.test.js)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bee21446588331b6ab58b4a77aac25