### PR TITLE
feat: add note callback for live streaming

### DIFF
--- a/src/utils/summarizer.js
+++ b/src/utils/summarizer.js
@@ -1,0 +1,15 @@
+export function generateNotesFromResponse(resp) {
+  try {
+    const text = typeof resp === 'string' ? resp : resp?.text || '';
+    const trimmed = text.trim();
+    if (!trimmed) return null;
+    return {
+      id: Date.now().toString(36),
+      text: trimmed,
+      timestamp: Date.now(),
+    };
+  } catch (e) {
+    return null;
+  }
+}
+


### PR DESCRIPTION
## Summary
- support optional `onNote` in `startLiveStreaming` and generate notes from final model messages
- track generated notes in `CheatingDaddyApp` and pass the new callback
- add `generateNotesFromResponse` helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bee21682608331b2fd1840fa4906f1