### PR TITLE
refactor: store notes as structured array

### DIFF
--- a/backend/historyStore.js
+++ b/backend/historyStore.js
@@ -41,12 +41,12 @@ function appendTurn(sessionId, data) {
             id: sessionId,
             timestamp: data.timestamp || Date.now(),
             conversationHistory: [],
-            notes: data.notes || '',
+            notes: Array.isArray(data.notes) ? data.notes : [],
         };
         history.sessions[sessionId] = session;
     }
 
-    if (typeof data.notes === 'string') {
+    if (Array.isArray(data.notes)) {
         session.notes = data.notes;
     }
 

--- a/src/components/app/CheatingDaddyApp.js
+++ b/src/components/app/CheatingDaddyApp.js
@@ -144,7 +144,7 @@ export class CheatingDaddyApp extends LitElement {
         advancedMode: { type: Boolean },
         sessionId: { type: String },
         transcripts: { type: Array },
-        notes: { type: String },
+        notes: { type: Array },
         _viewInstances: { type: Object, state: true },
         _isClickThrough: { state: true },
         _awaitingNewResponse: { state: true },
@@ -174,7 +174,7 @@ export class CheatingDaddyApp extends LitElement {
         this.shouldAnimateResponse = false;
         this.sessionId = null;
         this.transcripts = [];
-        this.notes = '';
+        this.notes = [];
         this.audioLevel = 0;
 
         // Apply layout mode to document root
@@ -415,12 +415,12 @@ export class CheatingDaddyApp extends LitElement {
         this.startTime = Date.now();
         this.sessionId = self.crypto?.randomUUID?.() ?? Date.now().toString();
         this.transcripts = [];
-        this.notes = '';
+        this.notes = [];
         try {
             await fetch(`http://localhost:3001/history/${this.sessionId}/turn`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ sessionStart: true, notes: '' }),
+                body: JSON.stringify({ sessionStart: true, notes: [] }),
             });
         } catch (error) {
             logger.error('Failed to start session history:', error);
@@ -483,8 +483,8 @@ export class CheatingDaddyApp extends LitElement {
     }
 
     async handleNotesChange(e) {
-        const newNotes = e?.detail?.value ?? e?.target?.value ?? '';
-        this.notes = newNotes;
+        const newNotes = e?.detail?.value ?? e?.target?.value ?? [];
+        this.notes = Array.isArray(newNotes) ? newNotes : [];
         if (!this.sessionId) return;
         try {
             await fetch(`http://localhost:3001/history/${this.sessionId}/turn`, {

--- a/src/components/app/SidePanel.js
+++ b/src/components/app/SidePanel.js
@@ -94,7 +94,7 @@ export class SidePanel extends LitElement {
 
     static properties = {
         transcripts: { type: Array },
-        notes: { type: String },
+        notes: { type: Array },
         selectedProfile: { type: String },
         exportFormat: { type: String },
     };
@@ -102,13 +102,16 @@ export class SidePanel extends LitElement {
     constructor() {
         super();
         this.transcripts = [];
-        this.notes = '';
+        this.notes = [];
         this.selectedProfile = 'interview';
         this.exportFormat = 'json';
     }
 
     _onNotesChange(e) {
-        this.notes = e.target.value;
+        const text = e.target.value;
+        const timestamp = this.notes[0]?.timestamp || Date.now();
+        const type = this.notes[0]?.type || 'manual';
+        this.notes = [{ text, type, timestamp }];
         this.dispatchEvent(
             new CustomEvent('notes-change', {
                 detail: { value: this.notes },
@@ -159,7 +162,7 @@ export class SidePanel extends LitElement {
             </div>
             <div class="notes">
                 <textarea
-                    .value=${this.notes}
+                    .value=${this.notes[0]?.text || ''}
                     @input=${this._onNotesChange}
                     placeholder="Notes..."
                 ></textarea>

--- a/src/components/views/HistoryView.js
+++ b/src/components/views/HistoryView.js
@@ -438,7 +438,7 @@ export class HistoryView extends LitElement {
             this.loading = true;
             const res = await fetch(`${API_BASE}/history/${sessionId}`);
             const data = await res.json();
-            this.selectedSession = { ...data, notes: data.notes || '' };
+            this.selectedSession = { ...data, notes: Array.isArray(data.notes) ? data.notes : [] };
         } catch (error) {
             logger.error('Error loading session transcript:', error);
         } finally {
@@ -469,7 +469,7 @@ export class HistoryView extends LitElement {
                     sessionId: this.selectedSession.id,
                     history: this.selectedSession.conversationHistory || [],
                 },
-                notes: this.selectedSession.notes || '',
+                notes: this.selectedSession.notes || [],
                 profile: this.selectedSession.profile || localStorage.getItem('selectedProfile') || '',
             });
             if (res?.success) {
@@ -652,11 +652,15 @@ export class HistoryView extends LitElement {
                 </div>
             </div>
             <div class="conversation-view">
-                ${notes
+                ${Array.isArray(notes) && notes.length > 0
                     ? html`
                           <div class="session-notes">
                               <div class="session-notes-title">Notes</div>
-                              <div class="session-notes-content">${notes}</div>
+                              <div class="session-notes-content">
+                                  ${notes.map(
+                                      note => html`<div class="note-item">${note.text}</div>`
+                                  )}
+                              </div>
                           </div>
                       `
                     : ''}

--- a/src/utils/__tests__/historyStore.notes.test.js
+++ b/src/utils/__tests__/historyStore.notes.test.js
@@ -20,25 +20,30 @@ test('Starting a session with sessionStart: true', () => {
     const session = historyStore.getSession(sessionId);
     assert.ok(session);
     assert.deepStrictEqual(session.conversationHistory, []);
+    assert.deepStrictEqual(session.notes, []);
 });
 
 test('Updating notes independently', () => {
     const sessionId = 'notes-update';
+    const note1 = { text: 'First note', type: 'manual', timestamp: 1 };
+    const note2 = { text: 'Updated note', type: 'manual', timestamp: 2 };
     historyStore.appendTurn(sessionId, { sessionStart: true });
-    historyStore.appendTurn(sessionId, { notes: 'First note' });
+    historyStore.appendTurn(sessionId, { notes: [note1] });
     let session = historyStore.getSession(sessionId);
-    assert.strictEqual(session.notes, 'First note');
-    historyStore.appendTurn(sessionId, { notes: 'Updated note' });
+    assert.deepStrictEqual(session.notes, [note1]);
+    historyStore.appendTurn(sessionId, { notes: [note2] });
     session = historyStore.getSession(sessionId);
-    assert.strictEqual(session.notes, 'Updated note');
+    assert.deepStrictEqual(session.notes, [note2]);
     assert.strictEqual(session.conversationHistory.length, 0);
 });
 
 test('getSession returns the latest notes', () => {
     const sessionId = 'latest-notes';
+    const oldNote = { text: 'Old note', type: 'manual', timestamp: 1 };
+    const newNote = { text: 'New note', type: 'manual', timestamp: 2 };
     historyStore.appendTurn(sessionId, { sessionStart: true });
-    historyStore.appendTurn(sessionId, { notes: 'Old note' });
-    historyStore.appendTurn(sessionId, { notes: 'New note' });
+    historyStore.appendTurn(sessionId, { notes: [oldNote] });
+    historyStore.appendTurn(sessionId, { notes: [newNote] });
     const session = historyStore.getSession(sessionId);
-    assert.strictEqual(session.notes, 'New note');
+    assert.deepStrictEqual(session.notes, [newNote]);
 });

--- a/src/utils/__tests__/sessionManager.test.js
+++ b/src/utils/__tests__/sessionManager.test.js
@@ -16,6 +16,7 @@ test('getEnabledTools respects googleSearch setting', async () => {
 });
 
 test('exportSession generates JSON blob with metadata', async () => {
+    const notes = [{ text: 'some notes', type: 'manual', timestamp: 0 }];
     const { blob, filename } = sessionManager.exportSession({
         format: 'json',
         session: {
@@ -28,18 +29,19 @@ test('exportSession generates JSON blob with metadata', async () => {
                 },
             ],
         },
-        notes: 'some notes',
+        notes,
         profile: 'interview',
     });
     assert.strictEqual(filename, 'session-abc.json');
     const text = await blob.text();
     const data = JSON.parse(text);
-    assert.strictEqual(data.notes, 'some notes');
+    assert.deepStrictEqual(data.notes, notes);
     assert.strictEqual(data.metadata.profile, 'interview');
     assert.strictEqual(data.conversation.length, 1);
 });
 
 test('exportSession generates Markdown blob', async () => {
+    const notes = [{ text: 'note', type: 'manual', timestamp: 0 }];
     const { blob } = sessionManager.exportSession({
         format: 'markdown',
         session: {
@@ -52,7 +54,7 @@ test('exportSession generates Markdown blob', async () => {
                 },
             ],
         },
-        notes: 'note',
+        notes,
         profile: 'interview',
     });
     const text = await blob.text();

--- a/src/utils/sessionManager.js
+++ b/src/utils/sessionManager.js
@@ -190,12 +190,12 @@ async function sendImage(geminiSessionRef, data) {
  *
  * @param {Object} opts
  * @param {string} [opts.format='json'] - Export format: 'json' or 'markdown'.
- * @param {string} [opts.notes=''] - Session notes to include.
+ * @param {Array<{text: string, type: string, timestamp: number}>} [opts.notes=[]] - Session notes to include.
  * @param {string} [opts.profile=''] - Selected profile name for metadata.
  * @param {Object} [opts.session] - Optional session data { sessionId, history }.
  * @returns {{ blob: Blob, filename: string }}
  */
-function exportSession({ format = 'json', notes = '', profile = '', session } = {}) {
+function exportSession({ format = 'json', notes = [], profile = '', session } = {}) {
     const exportedAt = new Date().toISOString();
 
     let sessionId;
@@ -221,8 +221,14 @@ function exportSession({ format = 'json', notes = '', profile = '', session } = 
 
     if (format === 'markdown' || format === 'md') {
         const lines = [`# Session ${sessionId}`, '', `- Profile: ${profile}`, `- Exported: ${exportedAt}`, ''];
-        if (notes) {
-            lines.push('## Notes', notes, '');
+        if (Array.isArray(notes) && notes.length > 0) {
+            lines.push('## Notes');
+            notes.forEach(note => {
+                const ts = new Date(note.timestamp).toISOString();
+                const type = note.type || 'note';
+                lines.push(`- (${ts}) [${type}] ${note.text}`);
+            });
+            lines.push('');
         }
         lines.push('## Conversation');
         history.forEach(turn => {


### PR DESCRIPTION
## Summary
- refactor session notes to use arrays of {text,type,timestamp}
- persist and export notes arrays across backend and UI components
- update tests for array-based note storage

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bee215802883319ede07d1bec86ed4