### PR TITLE
feat: display note stream beside assistant responses

### DIFF
--- a/src/components/app/CheatingDaddyApp.js
+++ b/src/components/app/CheatingDaddyApp.js
@@ -14,7 +14,7 @@ import '../views/SidePanel.js';
 import { startListening } from '../../utils/voiceAssistant.js';
 // Live streaming helper integrates with Gemini Live via backend
 import { startLiveStreaming } from '../../utils/liveStreamer.js';
-import { logger as defaultLogger } from '../../utils/logger.js';
+import defaultLogger from '../../utils/logger.js';
 
 // Use global logger if available, falling back to the imported logger or console
 const logger = globalThis.logger || defaultLogger || console;
@@ -145,6 +145,7 @@ export class CheatingDaddyApp extends LitElement {
         sessionId: { type: String },
         transcripts: { type: Array },
         notes: { type: String },
+        noteStream: { type: Array },
         _viewInstances: { type: Object, state: true },
         _isClickThrough: { state: true },
         _awaitingNewResponse: { state: true },
@@ -174,6 +175,7 @@ export class CheatingDaddyApp extends LitElement {
         this.shouldAnimateResponse = false;
         this.sessionId = null;
         this.transcripts = [];
+        this.noteStream = [];
         this.notes = '';
         this.audioLevel = 0;
 
@@ -599,6 +601,7 @@ export class CheatingDaddyApp extends LitElement {
                             .selectedProfile=${this.selectedProfile}
                             .onSendText=${message => this.handleSendText(message)}
                             .shouldAnimateResponse=${this.shouldAnimateResponse}
+                            .notes=${this.noteStream}
                             @response-index-changed=${this.handleResponseIndexChanged}
                             @response-animation-complete=${() => {
                                 this.shouldAnimateResponse = false;

--- a/src/components/app/NoteStreamPanel.js
+++ b/src/components/app/NoteStreamPanel.js
@@ -1,0 +1,42 @@
+import { html, css, LitElement } from '../../assets/lit-core-2.7.4.min.js';
+
+export class NoteStreamPanel extends LitElement {
+    static styles = css`
+        :host {
+            display: block;
+            width: 250px;
+            max-height: 100%;
+            overflow-y: auto;
+            background: var(--main-content-background);
+            border-left: 1px solid var(--border-color);
+            padding: var(--main-content-padding);
+            box-sizing: border-box;
+        }
+
+        .note {
+            margin-bottom: 8px;
+            font-size: 14px;
+            line-height: 1.4;
+            color: var(--text-color);
+        }
+    `;
+
+    static properties = {
+        notes: { type: Array },
+    };
+
+    constructor() {
+        super();
+        this.notes = [];
+    }
+
+    render() {
+        return html`
+            ${this.notes.map(
+                (note) => html`<div class="note">${note}</div>`
+            )}
+        `;
+    }
+}
+
+customElements.define('note-stream-panel', NoteStreamPanel);

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,6 +2,7 @@
 export { CheatingDaddyApp } from './app/CheatingDaddyApp.js';
 export { AppHeader } from './app/AppHeader.js';
 export { SidePanel } from './app/SidePanel.js';
+export { NoteStreamPanel } from './app/NoteStreamPanel.js';
 
 // View components
 export { MainView } from './views/MainView.js';

--- a/src/components/views/AssistantView.js
+++ b/src/components/views/AssistantView.js
@@ -1,4 +1,5 @@
 import { html, css, LitElement } from '../../assets/lit-core-2.7.4.min.js';
+import '../app/NoteStreamPanel.js';
 
 export class AssistantView extends LitElement {
     static styles = css`
@@ -13,8 +14,13 @@ export class AssistantView extends LitElement {
             cursor: default;
         }
 
-        .response-container {
+        .response-wrapper {
             height: calc(100% - 60px);
+            display: flex;
+        }
+
+        .response-container {
+            flex: 1;
             overflow-y: auto;
             border-radius: 10px;
             font-size: var(--response-font-size, 18px);
@@ -24,6 +30,11 @@ export class AssistantView extends LitElement {
             scroll-behavior: smooth;
             user-select: text;
             cursor: text;
+        }
+
+        note-stream-panel {
+            width: 250px;
+            margin-left: 16px;
         }
 
         /* Allow text selection for all content within the response container */
@@ -300,6 +311,7 @@ export class AssistantView extends LitElement {
         onSendText: { type: Function },
         shouldAnimateResponse: { type: Boolean },
         savedResponses: { type: Array },
+        notes: { type: Array },
     };
 
     constructor() {
@@ -315,6 +327,7 @@ export class AssistantView extends LitElement {
         } catch (e) {
             this.savedResponses = [];
         }
+        this.notes = [];
     }
 
     getProfileNames() {
@@ -596,7 +609,10 @@ export class AssistantView extends LitElement {
         const isSaved = this.isResponseSaved();
 
         return html`
-            <div class="response-container" id="responseContainer"></div>
+            <div class="response-wrapper">
+                <div class="response-container" id="responseContainer"></div>
+                <note-stream-panel .notes=${this.notes}></note-stream-panel>
+            </div>
 
             <div class="text-input-container">
                 <button class="nav-button" @click=${this.navigateToPreviousResponse} ?disabled=${this.currentResponseIndex <= 0}>

--- a/src/utils/liveStreamer.js
+++ b/src/utils/liveStreamer.js
@@ -1,5 +1,5 @@
 import { LLMClient } from '../services/llmClient.js';
-import { logger as defaultLogger } from './logger.js';
+import defaultLogger from './logger.js';
 
 // Fallback to console if the logger script fails to attach to globalThis
 const logger = globalThis.logger || defaultLogger || console;


### PR DESCRIPTION
## Summary
- add note stream panel component
- render `<note-stream-panel>` in assistant view with bound notes
- pass notes array from parent view
- fix logger imports to support node tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bee21633ec833186747629aeca4442