### PR TITLE
Load dotenv configuration in Electron entry points

### DIFF
--- a/apps/desktop/electron/main.js
+++ b/apps/desktop/electron/main.js
@@ -1,4 +1,5 @@
 // apps/desktop/electron/main.js
+import 'dotenv/config';
 import { app, BrowserWindow, ipcMain } from 'electron';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 if (require('electron-squirrel-startup')) {
     process.exit(0);
 }


### PR DESCRIPTION
## Summary
- initialize dotenv in main process entry points (`src/index.js` and `apps/desktop/electron/main.js`) to expose variables via `process.env`

## Testing
- `npm run lint`
- `npm test`
- `node -e "console.log('STEALTH before', process.env.STEALTH)"`
- `node -e "require('dotenv').config(); console.log('STEALTH after', process.env.STEALTH)"`


------
https://chatgpt.com/codex/tasks/task_e_68c17c0c6f4083319d0e06491c857f14