### PR TITLE
Use static process identifiers

### DIFF
--- a/src/utils/processRandomizer.js
+++ b/src/utils/processRandomizer.js
@@ -1,46 +1,25 @@
-// processRandomizer.js - Apply random process names at startup
+// processRandomizer.js - Return stable process names
 
-const { getCurrentRandomName, getCurrentRandomDisplayName, generateRandomWindowTitle } = require('./processNames');
+const IDENTIFIERS = {
+    processName: 'SalesWizard',
+    displayName: 'Sales Wizard',
+    windowTitle: 'Sales Wizard',
+};
 
 /**
- * Initialize random process names for the current session
- * This should be called early in the application startup
+ * Initialize process names for the current session.
+ * Returns static identifiers used throughout the application.
  */
 function initializeRandomProcessNames() {
-    logger.info('Initializing random process names for stealth...');
-
-    const randomName = getCurrentRandomName();
-    const randomDisplayName = getCurrentRandomDisplayName();
-    const windowTitle = generateRandomWindowTitle();
-
-    logger.info(`Process name: ${randomName}`);
-    logger.info(`Display name: ${randomDisplayName}`);
-    logger.info(`Window title: ${windowTitle}`);
-
-    // Set process title to appear as a different process in task manager
-    setRandomProcessTitle();
-
-    return {
-        processName: randomName,
-        displayName: randomDisplayName,
-        windowTitle: windowTitle,
-    };
+    return { ...IDENTIFIERS };
 }
 
 /**
- * Set a random process title for the current process
- * This changes how the process appears in task manager/process lists
+ * No-op setter for process title.
+ * Maintains compatibility with previous API by returning a fixed process name.
  */
 function setRandomProcessTitle() {
-    try {
-        const randomProcessName = getCurrentRandomName();
-        process.title = randomProcessName;
-        logger.info(`Set process title to: ${randomProcessName}`);
-        return randomProcessName;
-    } catch (error) {
-        logger.warn('Could not set process title:', error.message);
-        return null;
-    }
+    return IDENTIFIERS.processName;
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- replace process name randomizer with static identifiers
- return stable title from no-op `setRandomProcessTitle`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2c5b8c4508331af7ffe517dfc4150