### PR TITLE
Disable content protection and stealth features

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,18 +84,8 @@ function setupGeneralIpcHandlers() {
     });
 
     ipcMain.handle('update-content-protection', async () => {
-        try {
-            if (mainWindow) {
-                // Get content protection setting from localStorage via cheddar
-                const contentProtection = await mainWindow.webContents.executeJavaScript('cheddar.getContentProtection()');
-                mainWindow.setContentProtection(contentProtection);
-                logger.info('Content protection updated:', contentProtection);
-            }
-            return { success: true };
-        } catch (error) {
-            logger.error('Error updating content protection:', error);
-            return { success: false, error: error.message };
-        }
+        // Content protection updates are disabled; maintain false state.
+        return { success: true };
     });
 
     ipcMain.handle('get-random-display-name', async () => {

--- a/src/utils/stealthFeatures.js
+++ b/src/utils/stealthFeatures.js
@@ -44,14 +44,6 @@ function applyStealthMeasures(mainWindow) {
         }
     }
 
-    // Prevent screenshots if content protection is enabled
-    try {
-        mainWindow.setContentProtection(true);
-        logger.info('Content protection enabled');
-    } catch (error) {
-        logger.warn('Could not enable content protection:', error.message);
-    }
-
     // Randomize window user agent
     try {
         const userAgents = [


### PR DESCRIPTION
## Summary
- Disable content protection by default and remove stealth feature calls.
- Clean up content protection logic and update handler to keep protection off.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2c5b9f4b483318e9b72fbe02ab72a