### PR TITLE
Ensure env configuration supports STEALTH flag

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-# Copy to .env and fill in your configuration
+# Environment configuration for Sales Wizard
 GEMINI_API_KEY=your_api_key_here
 PORT=3001
 STEALTH=0

--- a/.gitignore
+++ b/.gitignore
@@ -62,8 +62,7 @@ pendingTurns.json
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variables file
-.env
+# dotenv environment variables
 .env.test
 
 # parcel-bundler cache (https://parceljs.org/)

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const { FusesPlugin } = require('@electron-forge/plugin-fuses');
 const { FuseV1Options, FuseVersion } = require('@electron/fuses');
 

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "main": "src/index.js",
   "scripts": {
     "start": "concurrently \"npm run start:backend\" \"npm run start:electron\"",
-    "start:electron": "electron-forge start",
+    "start:electron": "node -r dotenv/config node_modules/.bin/electron-forge start",
     "start:backend": "node backend/server.js",
-    "package": "electron-forge package",
-    "make": "electron-forge make",
-    "publish": "electron-forge publish",
+    "package": "node -r dotenv/config node_modules/.bin/electron-forge package",
+    "make": "node -r dotenv/config node_modules/.bin/electron-forge make",
+    "publish": "node -r dotenv/config node_modules/.bin/electron-forge publish",
     "lint": "eslint .",
     "test": "node -r ./src/utils/logger.js --test src/utils/__tests__/*.test.js",
     "format": "prettier --write ."


### PR DESCRIPTION
## Summary
- commit .env with default STEALTH=0 and document in example
- load env file in forge config and npm scripts so Electron builds honor .env
- track .env by updating gitignore

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2c5ba705c8331b29ef0ba94bc4698