### PR TITLE
Remove stealth behaviors and show Sales Wizard branding

### DIFF
--- a/src/components/views/CustomizeView.js
+++ b/src/components/views/CustomizeView.js
@@ -632,7 +632,6 @@ export class CustomizeView extends LitElement {
             toggleVisibility: isMac ? 'Cmd+\\' : 'Ctrl+\\',
             toggleClickThrough: isMac ? 'Cmd+M' : 'Ctrl+M',
             nextStep: isMac ? 'Cmd+Enter' : 'Ctrl+Enter',
-            panicHide: isMac ? 'Cmd+Esc' : 'Ctrl+Esc',
             toggleMic: isMac ? 'Cmd+Shift+M' : 'Ctrl+Shift+M',
             previousResponse: isMac ? 'Cmd+[' : 'Ctrl+[',
             nextResponse: isMac ? 'Cmd+]' : 'Ctrl+]',
@@ -707,11 +706,6 @@ export class CustomizeView extends LitElement {
                 key: 'toggleClickThrough',
                 name: 'Toggle Click-through Mode',
                 description: 'Enable/disable click-through functionality',
-            },
-            {
-                key: 'panicHide',
-                name: 'Panic Hide',
-                description: 'Hide overlay and stop capture',
             },
             {
                 key: 'toggleMic',

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,6 @@ const { app, BrowserWindow, shell, ipcMain, screen } = require('electron');
 const { createWindow, updateGlobalShortcuts } = require('./utils/window');
 const { setupGeminiIpcHandlers, stopMacOSAudioCapture, sendToRenderer } = require('./utils/gemini');
 const { registerSecureStoreIpc } = require('./utils/secureStore');
-const { initializeRandomProcessNames } = require('./utils/processRandomizer');
-const { applyAntiAnalysisMeasures } = require('./utils/stealthFeatures');
 
 const geminiSessionRef = { current: null };
 let mainWindow = null;
@@ -20,18 +18,14 @@ let contextParams = {
     disallowedTopics: '',
 };
 
-// Initialize random process names for stealth
-const randomNames = initializeRandomProcessNames();
+const APP_DISPLAY_NAME = 'Sales Wizard';
 
 function createMainWindow() {
-    mainWindow = createWindow(sendToRenderer, geminiSessionRef, randomNames);
+    mainWindow = createWindow(sendToRenderer, geminiSessionRef);
     return mainWindow;
 }
 
 app.whenReady().then(async () => {
-    // Apply anti-analysis measures with random delay
-    await applyAntiAnalysisMeasures();
-
     createMainWindow();
     setupGeminiIpcHandlers(geminiSessionRef);
     setupGeneralIpcHandlers();
@@ -98,12 +92,24 @@ function setupGeneralIpcHandlers() {
         }
     });
 
+    const resolveAppDisplayName = () => APP_DISPLAY_NAME;
+
+    ipcMain.handle('get-app-display-name', async () => {
+        try {
+            return resolveAppDisplayName();
+        } catch (error) {
+            logger.error('Error getting application display name:', error);
+            return APP_DISPLAY_NAME;
+        }
+    });
+
+    // Backwards compatibility for older preload scripts still invoking the legacy channel
     ipcMain.handle('get-random-display-name', async () => {
         try {
-            return randomNames ? randomNames.displayName : 'System Monitor';
+            return resolveAppDisplayName();
         } catch (error) {
-            logger.error('Error getting random display name:', error);
-            return 'System Monitor';
+            logger.error('Error getting application display name:', error);
+            return APP_DISPLAY_NAME;
         }
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,9 @@ require('dotenv').config();
 if (require('electron-squirrel-startup')) {
     process.exit(0);
 }
-require('dotenv').config();
-require("./utils/logger");
 
 const { app, BrowserWindow, shell, ipcMain, screen } = require('electron');
+const logger = require('./utils/logger');
 const { createWindow, updateGlobalShortcuts } = require('./utils/window');
 const { setupGeminiIpcHandlers, stopMacOSAudioCapture, sendToRenderer } = require('./utils/gemini');
 const { registerSecureStoreIpc } = require('./utils/secureStore');
@@ -19,6 +18,11 @@ let contextParams = {
 };
 
 const APP_DISPLAY_NAME = 'Sales Wizard';
+
+app.name = APP_DISPLAY_NAME;
+if (typeof app.setName === 'function') {
+    app.setName(APP_DISPLAY_NAME);
+}
 
 function createMainWindow() {
     mainWindow = createWindow(sendToRenderer, geminiSessionRef);
@@ -73,7 +77,7 @@ function setupGeneralIpcHandlers() {
 
     ipcMain.on('update-keybinds', (_event, newKeybinds) => {
         if (mainWindow) {
-            updateGlobalShortcuts(newKeybinds, mainWindow, sendToRenderer, geminiSessionRef);
+            updateGlobalShortcuts(newKeybinds, mainWindow, sendToRenderer);
         }
     });
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -23,7 +23,8 @@ const api = {
     ipcRenderer.invoke('update-google-search-setting', enabled),
   updateContentProtection: enabled =>
     ipcRenderer.invoke('update-content-protection', enabled),
-  getRandomDisplayName: () => ipcRenderer.invoke('get-random-display-name'),
+  getAppDisplayName: () => ipcRenderer.invoke('get-app-display-name'),
+  getRandomDisplayName: () => ipcRenderer.invoke('get-app-display-name'),
   exportSession: options => ipcRenderer.invoke('export-session', options),
   onUpdateResponse: handler => ipcRenderer.on('update-response', handler),
   removeUpdateResponseListener: handler =>

--- a/src/utils/appInfo.js
+++ b/src/utils/appInfo.js
@@ -1,3 +1,3 @@
 export function getAppName() {
-    return window.randomDisplayName || 'Cheating Daddy';
+    return window.appDisplayName || 'Sales Wizard';
 }

--- a/src/utils/renderer.js
+++ b/src/utils/renderer.js
@@ -1,5 +1,6 @@
 // renderer.js
 const ipcRenderer = (window.electron?.ipcRenderer) ?? require('electron').ipcRenderer;
+const logger = window.logger ?? console;
 
 // Initialize application display name for UI components
 window.appDisplayName = 'Sales Wizard';

--- a/src/utils/renderer.js
+++ b/src/utils/renderer.js
@@ -1,18 +1,22 @@
 // renderer.js
 const ipcRenderer = (window.electron?.ipcRenderer) ?? require('electron').ipcRenderer;
 
-// Initialize random display name for UI components
-window.randomDisplayName = null;
+// Initialize application display name for UI components
+window.appDisplayName = 'Sales Wizard';
 
-// Request random display name from main process
-window.electron?.getRandomDisplayName?.()
+const fetchAppDisplayName =
+    window.electron?.getAppDisplayName ?? window.electron?.getRandomDisplayName;
+
+fetchAppDisplayName?.()
     .then(name => {
-        window.randomDisplayName = name;
-        logger.info('Set random display name:', name);
+        if (typeof name === 'string' && name.trim().length > 0) {
+            window.appDisplayName = name;
+        }
+        logger.info('Using application display name:', window.appDisplayName);
     })
     .catch(err => {
-        logger.warn('Could not get random display name:', err);
-        window.randomDisplayName = 'System Monitor';
+        logger.warn('Could not resolve application display name:', err);
+        window.appDisplayName = 'Sales Wizard';
     });
 
 let mediaStream = null;

--- a/src/utils/window.js
+++ b/src/utils/window.js
@@ -3,6 +3,8 @@ const path = require('node:path');
 const fs = require('node:fs');
 const os = require('os');
 
+const logger = require('./logger');
+
 const APP_WINDOW_TITLE = 'Sales Wizard';
 
 let mouseEventsIgnored = false;
@@ -26,7 +28,7 @@ function ensureDataDirectories() {
     return { imageDir, audioDir };
 }
 
-function createWindow(sendToRenderer, geminiSessionRef) {
+function createWindow(sendToRenderer, _geminiSessionRef) {
     // Get layout preference (default to 'normal')
     let windowWidth = 840;
     let windowHeight = 460;
@@ -36,7 +38,7 @@ function createWindow(sendToRenderer, geminiSessionRef) {
 
     const backgroundColor = isMac || isWindows ? '#00000000' : '#202020';
 
-    const mainWindow = new BrowserWindow({
+    const windowOptions = {
         width: windowWidth,
         height: windowHeight,
         show: false,
@@ -59,7 +61,9 @@ function createWindow(sendToRenderer, geminiSessionRef) {
             webSecurity: true,
             allowRunningInsecureContent: false,
         },
-    });
+    };
+
+    const mainWindow = new BrowserWindow(windowOptions);
 
     const { session, desktopCapturer } = require('electron');
     session.defaultSession.setDisplayMediaRequestHandler(
@@ -144,17 +148,17 @@ function createWindow(sendToRenderer, geminiSessionRef) {
                         mainWindow.setContentProtection(true);
                     }
 
-                    updateGlobalShortcuts(keybinds, mainWindow, sendToRenderer, geminiSessionRef);
+                    updateGlobalShortcuts(keybinds, mainWindow, sendToRenderer);
                 })
                 .catch(() => {
                     // Default to content protection enabled
                     mainWindow.setContentProtection(true);
-                    updateGlobalShortcuts(keybinds, mainWindow, sendToRenderer, geminiSessionRef);
+                    updateGlobalShortcuts(keybinds, mainWindow, sendToRenderer);
                 });
         }, 150);
     });
 
-    setupWindowIpcHandlers(mainWindow, sendToRenderer, geminiSessionRef);
+    setupWindowIpcHandlers(mainWindow, sendToRenderer);
 
     return mainWindow;
 }
@@ -349,7 +353,7 @@ function updateGlobalShortcuts(keybinds, mainWindow, sendToRenderer) {
     }
 }
 
-function setupWindowIpcHandlers(mainWindow, sendToRenderer, _geminiSessionRef) {
+function setupWindowIpcHandlers(mainWindow, sendToRenderer) {
     ipcMain.on('view-changed', (event, view) => {
         if (view !== 'assistant' && !mainWindow.isDestroyed()) {
             mainWindow.setIgnoreMouseEvents(false);

--- a/src/utils/window.js
+++ b/src/utils/window.js
@@ -2,9 +2,8 @@ const { BrowserWindow, globalShortcut, ipcMain, screen, app } = require('electro
 const path = require('node:path');
 const fs = require('node:fs');
 const os = require('os');
-const { applyStealthMeasures, startTitleRandomization } = require('./stealthFeatures');
 
-const STEALTH = process.env.STEALTH === '1';
+const APP_WINDOW_TITLE = 'Sales Wizard';
 
 let mouseEventsIgnored = false;
 let windowResizing = false;
@@ -27,23 +26,29 @@ function ensureDataDirectories() {
     return { imageDir, audioDir };
 }
 
-function createWindow(sendToRenderer, geminiSessionRef, randomNames = null) {
+function createWindow(sendToRenderer, geminiSessionRef) {
     // Get layout preference (default to 'normal')
     let windowWidth = 840;
     let windowHeight = 460;
+
+    const isMac = process.platform === 'darwin';
+    const isWindows = process.platform === 'win32';
+
+    const backgroundColor = isMac || isWindows ? '#00000000' : '#202020';
 
     const mainWindow = new BrowserWindow({
         width: windowWidth,
         height: windowHeight,
         show: false,
         frame: false,
-        transparent: true,
-        hasShadow: false,
+        transparent: isMac || isWindows,
+        hasShadow: true,
         resizable: true,
         movable: true,
         focusable: true,
         alwaysOnTop: true,
-        backgroundColor: '#00000000',
+        title: APP_WINDOW_TITLE,
+        backgroundColor,
         skipTaskbar: false,
         webPreferences: {
             preload: path.join(__dirname, '../preload.js'),
@@ -77,6 +82,17 @@ function createWindow(sendToRenderer, geminiSessionRef, randomNames = null) {
     mainWindow.setContentProtection(true);
     mainWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
 
+    try {
+        if (isMac) {
+            mainWindow.setVibrancy('sidebar');
+            mainWindow.setVisualEffectState('active');
+        } else if (isWindows && typeof mainWindow.setBackgroundMaterial === 'function') {
+            mainWindow.setBackgroundMaterial('mica');
+        }
+    } catch (error) {
+        logger.warn('Unable to enable platform vibrancy:', error);
+    }
+
     mainWindow.once('ready-to-show', () => {
         mainWindow.show();
         mainWindow.focus();
@@ -91,16 +107,7 @@ function createWindow(sendToRenderer, geminiSessionRef, randomNames = null) {
 
     mainWindow.loadFile(path.join(__dirname, '../index.html'));
 
-    // Set window title to random name if provided
-    if (randomNames && randomNames.windowTitle) {
-        mainWindow.setTitle(randomNames.windowTitle);
-        logger.info(`Set window title to: ${randomNames.windowTitle}`);
-    }
-
-    if (STEALTH) {
-        applyStealthMeasures(mainWindow);
-        startTitleRandomization(mainWindow);
-    }
+    mainWindow.setTitle(APP_WINDOW_TITLE);
 
     // After window is created, check for layout preference and resize if needed
     mainWindow.webContents.once('dom-ready', () => {
@@ -162,7 +169,6 @@ function getDefaultKeybinds() {
         toggleVisibility: isMac ? 'Cmd+\\' : 'Ctrl+\\',
         toggleClickThrough: isMac ? 'Cmd+M' : 'Ctrl+M',
         nextStep: isMac ? 'Cmd+Enter' : 'Ctrl+Enter',
-        panicHide: isMac ? 'Cmd+Esc' : 'Ctrl+Esc',
         toggleMic: isMac ? 'Cmd+Shift+M' : 'Ctrl+Shift+M',
         previousResponse: isMac ? 'Cmd+[' : 'Ctrl+[',
         nextResponse: isMac ? 'Cmd+]' : 'Ctrl+]',
@@ -251,23 +257,6 @@ function updateGlobalShortcuts(keybinds, mainWindow, sendToRenderer) {
             logger.info(`Registered toggleClickThrough: ${keybinds.toggleClickThrough}`);
         } catch (error) {
             logger.error(`Failed to register toggleClickThrough (${keybinds.toggleClickThrough}):`, error);
-        }
-    }
-
-    // Panic hide shortcut
-    if (keybinds.panicHide) {
-        try {
-            globalShortcut.register(keybinds.panicHide, () => {
-                try {
-                    if (mainWindow.isVisible()) mainWindow.hide();
-                    mainWindow.webContents.executeJavaScript('cheddar && cheddar.stopCapture && cheddar.stopCapture()').catch(() => {});
-                } catch (err) {
-                    logger.error('Error during panicHide:', err);
-                }
-            });
-            logger.info(`Registered panicHide: ${keybinds.panicHide}`);
-        } catch (error) {
-            logger.error(`Failed to register panicHide (${keybinds.panicHide}):`, error);
         }
     }
 


### PR DESCRIPTION
## Summary
- remove the stealth process randomization pipeline and expose a stable Sales Wizard app name to renderers
- refresh the BrowserWindow setup to use the official Sales Wizard title, enable platform vibrancy, and drop the panic hide shortcut
- update preload and renderer utilities plus CustomizeView to use the new branded display name everywhere

## Testing
- npm run lint
- npm run test
- npm run start:electron *(fails in the container because `node-gyp` cannot rebuild `active-win` without desktop tooling)*

------
https://chatgpt.com/codex/tasks/task_e_68cb7284a28c8331a1c5a9de56d68dbc