### PR TITLE
Normalize frontend backend endpoint configuration

### DIFF
--- a/src/components/app/SalesWizardApp.js
+++ b/src/components/app/SalesWizardApp.js
@@ -15,9 +15,11 @@ import { startListening } from '../../utils/voiceAssistant.js';
 // Live streaming helper integrates with Gemini Live via backend
 import { startLiveStreaming } from '../../utils/liveStreamer.js';
 import defaultLogger from '../../utils/logger.js';
+import { resolveBackendOrigin } from '../../services/backendConfig.js';
 
 // Use global logger if available, falling back to the imported logger or console
 const logger = globalThis.logger || defaultLogger || console;
+const API_BASE = resolveBackendOrigin();
 
 export class SalesWizardApp extends LitElement {
     static styles = css`
@@ -213,7 +215,7 @@ export class SalesWizardApp extends LitElement {
         // so it can be cleaned up in disconnectedCallback().
         this._stopVoiceAssistant = startListening(async transcript => {
             try {
-                const res = await fetch('http://localhost:3001/ask', {
+                const res = await fetch(`${API_BASE}/ask`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ prompt: transcript }),
@@ -227,7 +229,7 @@ export class SalesWizardApp extends LitElement {
                             { transcription: transcript, ai_response: data.reply },
                         ];
                         try {
-                            await fetch(`http://localhost:3001/history/${this.sessionId}/turn`, {
+                            await fetch(`${API_BASE}/history/${this.sessionId}/turn`, {
                                 method: 'POST',
                                 headers: { 'Content-Type': 'application/json' },
                                 body: JSON.stringify({
@@ -426,7 +428,7 @@ export class SalesWizardApp extends LitElement {
         this.notes = [];
         this.noteText = '';
         try {
-            await fetch(`http://localhost:3001/history/${this.sessionId}/turn`, {
+            await fetch(`${API_BASE}/history/${this.sessionId}/turn`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ sessionStart: true, notes: '' }),
@@ -496,7 +498,7 @@ export class SalesWizardApp extends LitElement {
         this.noteText = newNotes;
         if (!this.sessionId) return;
         try {
-            await fetch(`http://localhost:3001/history/${this.sessionId}/turn`, {
+            await fetch(`${API_BASE}/history/${this.sessionId}/turn`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ notes: this.noteText }),

--- a/src/components/views/AdvancedView.js
+++ b/src/components/views/AdvancedView.js
@@ -1,7 +1,8 @@
 import { html, css, LitElement } from '../../assets/lit-core-2.7.4.min.js';
 import { resizeLayout } from '../../utils/windowResize.js';
+import { resolveBackendOrigin } from '../../services/backendConfig.js';
 
-const API_BASE = 'http://localhost:3001';
+const API_BASE = resolveBackendOrigin();
 
 export class AdvancedView extends LitElement {
     static styles = css`

--- a/src/components/views/HistoryView.js
+++ b/src/components/views/HistoryView.js
@@ -1,7 +1,8 @@
 import { html, css, LitElement } from '../../assets/lit-core-2.7.4.min.js';
 import { resizeLayout } from '../../utils/windowResize.js';
+import { resolveBackendOrigin } from '../../services/backendConfig.js';
 
-const API_BASE = 'http://localhost:3001';
+const API_BASE = resolveBackendOrigin();
 
 export class HistoryView extends LitElement {
     static styles = css`

--- a/src/services/backendConfig.js
+++ b/src/services/backendConfig.js
@@ -1,0 +1,91 @@
+const DEFAULT_BACKEND_PORT = 3001;
+
+const stripTrailingSlash = value => (typeof value === 'string' ? value.replace(/\/+$/, '') : value);
+
+const getGlobalOverride = key => {
+  if (typeof globalThis !== 'undefined' && globalThis[key]) {
+    return String(globalThis[key]);
+  }
+  return undefined;
+};
+
+const getProcessEnv = key => {
+  if (typeof process !== 'undefined' && process?.env && process.env[key]) {
+    return process.env[key];
+  }
+  return undefined;
+};
+
+const getBackendOverride = () =>
+  getProcessEnv('BACKEND_URL') ||
+  getProcessEnv('SALES_WIZARD_BACKEND_URL') ||
+  getGlobalOverride('SALES_WIZARD_BACKEND_URL');
+
+const getLiveWsOverride = () =>
+  getProcessEnv('LIVE_WS_URL') ||
+  getProcessEnv('SALES_WIZARD_LIVE_WS_URL') ||
+  getGlobalOverride('SALES_WIZARD_LIVE_WS_URL');
+
+const normaliseUrl = url => {
+  if (!url) return url;
+  try {
+    const parsed = new URL(url);
+    if (!parsed.pathname || parsed.pathname === '/') {
+      parsed.pathname = '';
+    }
+    parsed.hash = '';
+    return stripTrailingSlash(parsed.toString());
+  } catch (err) {
+    return stripTrailingSlash(url);
+  }
+};
+
+function resolveBackendOrigin() {
+  const override = normaliseUrl(getBackendOverride());
+  if (override) {
+    return override;
+  }
+
+  if (typeof window !== 'undefined' && window.location) {
+    const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:';
+    const hostname = window.location.hostname || 'localhost';
+    return `${protocol}//${hostname}:${DEFAULT_BACKEND_PORT}`;
+  }
+
+  return `http://localhost:${DEFAULT_BACKEND_PORT}`;
+}
+
+function resolveLiveWsUrl() {
+  const override = stripTrailingSlash(getLiveWsOverride());
+  if (override) {
+    return override;
+  }
+
+  try {
+    const origin = resolveBackendOrigin();
+    const parsed = new URL(origin);
+    const protocol = parsed.protocol === 'https:' ? 'wss:' : 'ws:';
+    const hostname = parsed.hostname || 'localhost';
+    const port = parsed.port || String(DEFAULT_BACKEND_PORT);
+    return `${protocol}//${hostname}:${port}/live`;
+  } catch (err) {
+    const origin = resolveBackendOrigin();
+    const protocol = origin.startsWith('https') ? 'wss:' : 'ws:';
+    const stripped = origin.replace(/^https?:\/\//, '');
+    const withPort = stripped.includes(':') ? stripped : `${stripped}:${DEFAULT_BACKEND_PORT}`;
+    return `${protocol}//${withPort}/live`;
+  }
+}
+
+const api = {
+  DEFAULT_BACKEND_PORT,
+  resolveBackendOrigin,
+  resolveLiveWsUrl,
+};
+
+export { DEFAULT_BACKEND_PORT, resolveBackendOrigin, resolveLiveWsUrl };
+export default api;
+
+if (typeof module !== 'undefined') {
+  module.exports = api;
+}

--- a/src/services/liveSession.js
+++ b/src/services/liveSession.js
@@ -4,7 +4,9 @@
  * is ready and forwards server responses to consumer callbacks.
  */
 
-const DEFAULT_URL = 'ws://localhost:3001/live';
+import { resolveLiveWsUrl } from './backendConfig.js';
+
+const DEFAULT_URL = resolveLiveWsUrl();
 
 export class LiveSession {
     /**

--- a/src/services/llmClient.js
+++ b/src/services/llmClient.js
@@ -1,7 +1,9 @@
 // Unified LLM client for live interactions over WebSocket.
 // Mirrors the desktop implementation but with browser-friendly defaults.
 
-const DEFAULT_WS = 'ws://localhost:8787/ws/live';
+import { resolveLiveWsUrl } from './backendConfig.js';
+
+const DEFAULT_WS = resolveLiveWsUrl();
 
 export class LLMClient {
     /** @type {WebSocket|null} */

--- a/src/utils/conversationStore.js
+++ b/src/utils/conversationStore.js
@@ -1,8 +1,9 @@
 const { sendToRenderer } = require('./ipcUtils');
 const fs = require('fs');
 const path = require('path');
+const { resolveBackendOrigin } = require('../services/backendConfig.js');
 
-const API_BASE = process.env.BACKEND_URL || 'http://localhost:3001';
+const API_BASE = resolveBackendOrigin();
 const PENDING_FILE = path.join(__dirname, '../../pendingTurns.json');
 
 let pendingTurns = [];


### PR DESCRIPTION
## Summary
- add a shared backend configuration helper that derives the default REST and WebSocket endpoints from overrides or the host environment
- update the browser overlay clients to consume the helper so live sockets and history fetches default to ws://<host>:3001 without hard-coded URLs
- align the renderer-side conversation store with the same helper for consistent history persistence defaults

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbe77ee0c8833183eca2a701853ad2