### PR TITLE
Add structured connection, audio, and screen status indicators

### DIFF
--- a/src/components/app/AppHeader.js
+++ b/src/components/app/AppHeader.js
@@ -53,6 +53,69 @@ export class AppHeader extends LitElement {
             color: var(--header-actions-color);
         }
 
+        .status-indicators {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+        }
+
+        .status-indicator {
+            width: 28px;
+            height: 28px;
+            border-radius: 8px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: var(--status-indicator-background, rgba(255, 255, 255, 0.05));
+            border: 1px solid var(--status-indicator-border, rgba(255, 255, 255, 0.08));
+            color: var(--header-actions-color);
+            transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+            -webkit-app-region: no-drag;
+        }
+
+        .status-indicator svg {
+            width: 16px;
+            height: 16px;
+        }
+
+        .status-indicator.connected,
+        .status-indicator.capturing,
+        .status-indicator.sharing {
+            color: var(--status-indicator-success, #34d399);
+            border-color: rgba(52, 211, 153, 0.4);
+            background: rgba(52, 211, 153, 0.08);
+        }
+
+        .status-indicator.connecting {
+            color: var(--status-indicator-warning, #facc15);
+            border-color: rgba(250, 204, 21, 0.4);
+            background: rgba(250, 204, 21, 0.08);
+        }
+
+        .status-indicator.error {
+            color: var(--status-indicator-error, #f87171);
+            border-color: rgba(248, 113, 113, 0.4);
+            background: rgba(248, 113, 113, 0.08);
+        }
+
+        .status-indicator.idle,
+        .status-indicator.disconnected,
+        .status-indicator.unknown {
+            color: var(--status-indicator-idle, rgba(255, 255, 255, 0.6));
+        }
+
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+
         .button {
             background: var(--button-background);
             color: var(--text-color);
@@ -122,6 +185,12 @@ export class AppHeader extends LitElement {
         onAdvancedClick: { type: Function },
         appName: { type: String },
         audioLevel: { type: Number },
+        connectionState: { type: String },
+        audioState: { type: String },
+        screenState: { type: String },
+        connectionMessage: { type: String },
+        audioMessage: { type: String },
+        screenMessage: { type: String },
     };
 
     constructor() {
@@ -142,6 +211,12 @@ export class AppHeader extends LitElement {
         this._timerInterval = null;
         this.audioLevel = 0;
         this._appNameInterval = null;
+        this.connectionState = 'disconnected';
+        this.audioState = 'idle';
+        this.screenState = 'idle';
+        this.connectionMessage = 'WebSocket disconnected';
+        this.audioMessage = 'Microphone idle';
+        this.screenMessage = 'Screen capture idle';
     }
 
     connectedCallback() {
@@ -251,7 +326,10 @@ export class AppHeader extends LitElement {
                     ${this.currentView === 'assistant'
                         ? html`
                               <span>${elapsedTime}</span>
-                              <span>${this.statusText}</span>
+                              ${this.renderStatusIndicators()}
+                              ${this.statusText
+                                  ? html`<span class="sr-only" aria-live="polite">${this.statusText}</span>`
+                                  : ''}
                           `
                         : ''}
                     ${this.currentView === 'main'
@@ -453,6 +531,112 @@ export class AppHeader extends LitElement {
                 </div>
             </div>
         `;
+    }
+
+    renderStatusIndicators() {
+        const indicators = [
+            {
+                type: 'connection',
+                state: this.connectionState,
+                message: this.connectionMessage,
+            },
+            {
+                type: 'audio',
+                state: this.audioState,
+                message: this.audioMessage,
+            },
+            {
+                type: 'screen',
+                state: this.screenState,
+                message: this.screenMessage,
+            },
+        ];
+
+        return html`
+            <div class="status-indicators" role="group" aria-label="Streaming status">
+                ${indicators.map(config => this.renderIndicator(config))}
+            </div>
+        `;
+    }
+
+    renderIndicator({ type, state, message }) {
+        const normalizedState = state || 'unknown';
+        const label = this.getIndicatorLabel(type);
+        const stateLabel = this.getIndicatorStateLabel(type, normalizedState);
+        const tooltip = message || `${label}: ${stateLabel}`;
+        return html`
+            <div
+                class="status-indicator ${normalizedState}"
+                data-indicator=${type}
+                data-state=${normalizedState}
+                title=${tooltip}
+                role="status"
+                aria-label="${label}: ${stateLabel}"
+            >
+                ${this.renderIndicatorIcon(type)}
+            </div>
+        `;
+    }
+
+    getIndicatorLabel(type) {
+        const labels = {
+            connection: 'Connection',
+            audio: 'Microphone',
+            screen: 'Screen capture',
+        };
+        return labels[type] || type;
+    }
+
+    getIndicatorStateLabel(type, state) {
+        const stateLabels = {
+            connection: {
+                connected: 'Connected',
+                connecting: 'Connecting',
+                disconnected: 'Disconnected',
+                error: 'Error',
+                unknown: 'Unknown',
+            },
+            audio: {
+                capturing: 'Active',
+                idle: 'Idle',
+                error: 'Error',
+                unknown: 'Unknown',
+            },
+            screen: {
+                sharing: 'Sharing',
+                idle: 'Idle',
+                error: 'Error',
+                unknown: 'Unknown',
+            },
+        };
+        return stateLabels[type]?.[state] || stateLabels[type]?.unknown || state;
+    }
+
+    renderIndicatorIcon(type) {
+        switch (type) {
+            case 'connection':
+                return html`<?xml version="1.0" encoding="UTF-8"?><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M6.343 17.657a8 8 0 0 1 0-11.314"></path>
+                    <path d="M17.657 6.343a8 8 0 0 1 0 11.314"></path>
+                    <path d="M8.464 15.536a5 5 0 0 1 0-7.072"></path>
+                    <path d="M15.536 8.464a5 5 0 0 1 0 7.072"></path>
+                    <circle cx="12" cy="12" r="1.2" fill="currentColor" stroke="none"></circle>
+                </svg>`;
+            case 'audio':
+                return html`<?xml version="1.0" encoding="UTF-8"?><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M12 3a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V6a3 3 0 0 0-3-3Z"></path>
+                    <path d="M19 10v2a7 7 0 0 1-14 0v-2"></path>
+                    <path d="M12 19v2"></path>
+                </svg>`;
+            case 'screen':
+                return html`<?xml version="1.0" encoding="UTF-8"?><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="3" y="4" width="18" height="12" rx="2"></rect>
+                    <path d="M8 20h8"></path>
+                    <path d="M12 16v4"></path>
+                </svg>`;
+            default:
+                return html``;
+        }
     }
 }
 

--- a/src/components/app/SalesWizardApp.js
+++ b/src/components/app/SalesWizardApp.js
@@ -7,7 +7,7 @@ import '../views/HistoryView.js';
 import '../views/AssistantView.js';
 import '../views/OnboardingView.js';
 import '../views/AdvancedView.js';
-import '../views/SidePanel.js';
+import './SidePanel.js';
 
 // Voice assistant helper provides speech recognition via the Web Speech API.
 // It exports a startListening() function that returns a stop function.
@@ -133,6 +133,12 @@ export class SalesWizardApp extends LitElement {
     static properties = {
         currentView: { type: String },
         statusText: { type: String },
+        connectionState: { type: String },
+        audioState: { type: String },
+        screenState: { type: String },
+        connectionMessage: { type: String },
+        audioMessage: { type: String },
+        screenMessage: { type: String },
         startTime: { type: Number },
         isRecording: { type: Boolean },
         sessionActive: { type: Boolean },
@@ -159,6 +165,12 @@ export class SalesWizardApp extends LitElement {
         super();
         this.currentView = localStorage.getItem('onboardingCompleted') ? 'main' : 'onboarding';
         this.statusText = '';
+        this.connectionState = 'disconnected';
+        this.audioState = 'idle';
+        this.screenState = 'idle';
+        this.connectionMessage = 'WebSocket disconnected';
+        this.audioMessage = 'Microphone idle';
+        this.screenMessage = 'Screen capture idle';
         this.startTime = null;
         this.isRecording = false;
         this.sessionActive = false;
@@ -296,16 +308,218 @@ export class SalesWizardApp extends LitElement {
         }
     }
 
-    setStatus(text) {
-        this.statusText = text;
+    setStatus(status) {
+        const normalized = this._normalizeStatusPayload(status);
+        const messageForText =
+            normalized.message ||
+            normalized.connection?.message ||
+            normalized.audio?.message ||
+            normalized.screen?.message ||
+            (typeof status === 'string' ? status : '');
 
-        // Mark response as complete when we get certain status messages
-        if (text.includes('Ready') || text.includes('Listening') || text.includes('Error')) {
-            this._currentResponseIsComplete = true;
-            logger.info('[setStatus] Marked current response as complete');
-            const last = this.responses?.length ? this.responses[this.responses.length - 1] : null;
-            if (last) this.maybeSpeak(last);
+        if (normalized.connection) {
+            const { state, message } = normalized.connection;
+            if (state) this.connectionState = state;
+            if (message) this.connectionMessage = message;
         }
+
+        if (normalized.audio) {
+            const { state, message } = normalized.audio;
+            if (state) this.audioState = state;
+            if (message) this.audioMessage = message;
+        }
+
+        if (normalized.screen) {
+            const { state, message } = normalized.screen;
+            if (state) this.screenState = state;
+            if (message) this.screenMessage = message;
+        }
+
+        if (messageForText) {
+            this.statusText = messageForText;
+
+            // Mark response as complete when we get certain status messages
+            if (
+                messageForText.includes('Ready') ||
+                messageForText.includes('Listening') ||
+                messageForText.includes('Error')
+            ) {
+                this._currentResponseIsComplete = true;
+                logger.info('[setStatus] Marked current response as complete');
+                const last = this.responses?.length ? this.responses[this.responses.length - 1] : null;
+                if (last) this.maybeSpeak(last);
+            }
+        }
+    }
+
+    _normalizeStatusPayload(status) {
+        const normalized = {
+            message: '',
+            connection: null,
+            audio: null,
+            screen: null,
+        };
+
+        if (status && typeof status === 'object') {
+            const baseMessage = this._extractMessage(status);
+            normalized.message = baseMessage;
+
+            if ('connection' in status || status.type === 'connection') {
+                normalized.connection = this._coerceState('connection', status.connection ?? status.state ?? status.value, baseMessage || status.message || status.msg);
+            }
+
+            if ('audio' in status || status.type === 'audio') {
+                normalized.audio = this._coerceState('audio', status.audio ?? status.state ?? status.value, baseMessage || status.message || status.msg);
+            }
+
+            if ('screen' in status || status.type === 'screen') {
+                normalized.screen = this._coerceState('screen', status.screen ?? status.state ?? status.value, baseMessage || status.message || status.msg);
+            }
+
+            if (!normalized.connection && status.states?.connection) {
+                normalized.connection = this._coerceState('connection', status.states.connection, baseMessage);
+            }
+
+            if (!normalized.audio && status.states?.audio) {
+                normalized.audio = this._coerceState('audio', status.states.audio, baseMessage);
+            }
+
+            if (!normalized.screen && status.states?.screen) {
+                normalized.screen = this._coerceState('screen', status.states.screen, baseMessage);
+            }
+
+            if (!normalized.connection && typeof status.connection === 'object') {
+                normalized.connection = this._coerceState('connection', status.connection?.state ?? status.connection?.value, status.connection?.message ?? baseMessage);
+            }
+            if (!normalized.audio && typeof status.audio === 'object') {
+                normalized.audio = this._coerceState('audio', status.audio?.state ?? status.audio?.value, status.audio?.message ?? baseMessage);
+            }
+            if (!normalized.screen && typeof status.screen === 'object') {
+                normalized.screen = this._coerceState('screen', status.screen?.state ?? status.screen?.value, status.screen?.message ?? baseMessage);
+            }
+
+            return normalized;
+        }
+
+        if (typeof status === 'string') {
+            normalized.message = status;
+            const connectionState = this._inferStateFromMessage('connection', status);
+            if (connectionState) normalized.connection = { state: connectionState, message: status };
+            const audioState = this._inferStateFromMessage('audio', status);
+            if (audioState) normalized.audio = { state: audioState, message: status };
+            const screenState = this._inferStateFromMessage('screen', status);
+            if (screenState) normalized.screen = { state: screenState, message: status };
+        }
+
+        return normalized;
+    }
+
+    _extractMessage(status) {
+        if (!status || typeof status !== 'object') return '';
+        if (typeof status.message === 'string') return status.message;
+        if (typeof status.msg === 'string') return status.msg;
+        if (typeof status.text === 'string') return status.text;
+        return '';
+    }
+
+    _coerceState(kind, rawState, message) {
+        if (!rawState && rawState !== 0) return null;
+        const state = this._mapState(kind, rawState);
+        if (!state) return null;
+        const defaults = {
+            connection: {
+                connected: 'WebSocket connected',
+                connecting: 'Connecting to WebSocket',
+                disconnected: 'WebSocket disconnected',
+                error: 'WebSocket error',
+            },
+            audio: {
+                capturing: 'Microphone streaming',
+                idle: 'Microphone idle',
+                error: 'Microphone error',
+            },
+            screen: {
+                sharing: 'Screen sharing active',
+                idle: 'Screen capture idle',
+                error: 'Screen capture error',
+            },
+        };
+        return { state, message: message || defaults[kind]?.[state] || '' };
+    }
+
+    _mapState(kind, value) {
+        if (value == null) return null;
+        const key = String(value).toLowerCase();
+        const map = {
+            connection: {
+                connected: 'connected',
+                connect: 'connected',
+                open: 'connected',
+                ready: 'connected',
+                online: 'connected',
+                connecting: 'connecting',
+                pending: 'connecting',
+                opening: 'connecting',
+                disconnected: 'disconnected',
+                closed: 'disconnected',
+                ending: 'disconnected',
+                ended: 'disconnected',
+                idle: 'disconnected',
+                error: 'error',
+                failed: 'error',
+                timeout: 'error',
+            },
+            audio: {
+                capturing: 'capturing',
+                recording: 'capturing',
+                listening: 'capturing',
+                active: 'capturing',
+                starting: 'capturing',
+                idle: 'idle',
+                stopped: 'idle',
+                muted: 'idle',
+                ended: 'idle',
+                error: 'error',
+                failed: 'error',
+                denied: 'error',
+            },
+            screen: {
+                sharing: 'sharing',
+                capturing: 'sharing',
+                streaming: 'sharing',
+                active: 'sharing',
+                idle: 'idle',
+                stopped: 'idle',
+                ended: 'idle',
+                off: 'idle',
+                error: 'error',
+                failed: 'error',
+                blocked: 'error',
+                denied: 'error',
+            },
+        };
+
+        return map[kind]?.[key] ?? null;
+    }
+
+    _inferStateFromMessage(kind, message) {
+        if (kind === 'connection') {
+            if (/(ws open|connected|ready|live session connected)/i.test(message)) return 'connected';
+            if (/(connecting|opening|initialising|initializing)/i.test(message)) return 'connecting';
+            if (/(closed|ended|disconnected|session closed)/i.test(message)) return 'disconnected';
+            if (/(error|invalid|timeout|failed)/i.test(message)) return 'error';
+        }
+        if (kind === 'audio') {
+            if (/(listening|microphone (active|streaming)|audio capture started)/i.test(message)) return 'capturing';
+            if (/(microphone idle|audio capture stopped|microphone muted)/i.test(message)) return 'idle';
+            if (/(audio|microphone).*(error|denied|failed)/i.test(message)) return 'error';
+        }
+        if (kind === 'screen') {
+            if (/(screen capture (started|active)|sharing screen|screen streaming)/i.test(message)) return 'sharing';
+            if (/(screen capture ended|stopped|screen idle)/i.test(message)) return 'idle';
+            if (/(screen capture request was blocked|screen streaming failed|screen capture error)/i.test(message)) return 'error';
+        }
+        return null;
     }
 
     maybeSpeak(text) {
@@ -643,6 +857,12 @@ export class SalesWizardApp extends LitElement {
                     <app-header
                         .currentView=${this.currentView}
                         .statusText=${this.statusText}
+                        .connectionState=${this.connectionState}
+                        .audioState=${this.audioState}
+                        .screenState=${this.screenState}
+                        .connectionMessage=${this.connectionMessage}
+                        .audioMessage=${this.audioMessage}
+                        .screenMessage=${this.screenMessage}
                         .startTime=${this.startTime}
                         .advancedMode=${this.advancedMode}
                         .audioLevel=${this.audioLevel}

--- a/src/services/llmClient.js
+++ b/src/services/llmClient.js
@@ -25,6 +25,7 @@ export class LLMClient {
         return new Promise((resolve, reject) => {
             try {
                 this.ws = new WebSocket(this.url);
+                this._emitStatus({ connection: 'connecting', message: 'Opening WebSocket' });
                 let opened = false;
                 const timeout = setTimeout(() => {
                     if (!opened) {
@@ -49,11 +50,11 @@ export class LLMClient {
                         responseModalities,
                         systemInstruction: instr,
                     });
-                    this.onStatus('WS open');
+                    this._emitStatus({ connection: 'connected', message: 'WS open' });
                     resolve(true);
                 };
                 this.ws.onclose = () => {
-                    this.onStatus('WS closed');
+                    this._emitStatus({ connection: 'disconnected', message: 'WS closed' });
                     if (!opened) {
                         clearTimeout(timeout);
                         const msg = 'WS closed before open';
@@ -63,6 +64,7 @@ export class LLMClient {
                 };
                 this.ws.onerror = e => {
                     const msg = `WS error: ${e?.message || String(e)}`;
+                    this._emitStatus({ connection: 'error', message: msg });
                     this.onError(msg);
                     if (!opened) {
                         clearTimeout(timeout);
@@ -72,7 +74,7 @@ export class LLMClient {
                 this.ws.onmessage = evt => {
                     try {
                         const msg = JSON.parse(evt.data);
-                        if (msg.type === 'status') this.onStatus(msg.msg);
+                        if (msg.type === 'status') this._emitStatus(this._formatStatusPayload(msg.msg));
                         else if (msg.type === 'error') this.onError(msg.msg);
                         else if (msg.type === 'model_text') this.onText(msg.text);
                         else if (msg.type === 'model_audio') this.onAudio(msg.data, msg.mime);
@@ -100,6 +102,57 @@ export class LLMClient {
         } catch (e) {
             return undefined;
         }
+    }
+
+    _emitStatus(payload) {
+        try {
+            this.onStatus(payload);
+        } catch (_e) {
+            /* empty */
+        }
+    }
+
+    _formatStatusPayload(status) {
+        if (status && typeof status === 'object') {
+            return {
+                ...status,
+                message: typeof status.message === 'string' ? status.message : status.msg || status.text || '',
+            };
+        }
+
+        if (typeof status === 'string') {
+            const payload = { message: status };
+            const connection = this._inferState('connection', status);
+            if (connection) payload.connection = connection;
+            const audio = this._inferState('audio', status);
+            if (audio) payload.audio = audio;
+            const screen = this._inferState('screen', status);
+            if (screen) payload.screen = screen;
+            return payload;
+        }
+
+        return { message: status ? String(status) : '' };
+    }
+
+    _inferState(kind, message) {
+        if (typeof message !== 'string') return null;
+        if (kind === 'connection') {
+            if (/(ws open|connected|ready|live session connected)/i.test(message)) return 'connected';
+            if (/(connecting|opening|initialising|initializing)/i.test(message)) return 'connecting';
+            if (/(closed|ended|disconnected|session closed)/i.test(message)) return 'disconnected';
+            if (/(error|invalid|timeout|failed)/i.test(message)) return 'error';
+        }
+        if (kind === 'audio') {
+            if (/(listening|microphone (active|streaming)|audio capture started)/i.test(message)) return 'capturing';
+            if (/(microphone idle|audio capture stopped|microphone muted)/i.test(message)) return 'idle';
+            if (/(audio|microphone).*(error|denied|failed)/i.test(message)) return 'error';
+        }
+        if (kind === 'screen') {
+            if (/(screen capture (started|active)|sharing screen|screen streaming)/i.test(message)) return 'sharing';
+            if (/(screen capture ended|stopped|screen idle)/i.test(message)) return 'idle';
+            if (/(screen capture request was blocked|screen streaming failed|screen capture error)/i.test(message)) return 'error';
+        }
+        return null;
     }
 
     _send(obj) {

--- a/src/utils/__tests__/liveStreamer.test.js
+++ b/src/utils/__tests__/liveStreamer.test.js
@@ -61,12 +61,19 @@ test('screen track end stops interval and notifies status', async () => {
 
   assert.strictEqual(clearIntervalMock.mock.callCount(), 1);
   assert.deepStrictEqual(clearIntervalMock.mock.calls[0].arguments, [123]);
-  assert.deepStrictEqual(onStatus.mock.calls.at(-1).arguments, ['Screen capture ended']);
+  const screenStatuses = onStatus.mock.calls
+    .map(call => call.arguments[0])
+    .filter(arg => arg && typeof arg === 'object' && 'screen' in arg);
+  assert.ok(screenStatuses.length >= 1);
+  assert.deepStrictEqual(screenStatuses.at(-1), { screen: 'idle', message: 'Screen capture ended' });
 
   // Calling returned cleanup should not throw and should not double clear interval
   stopFn();
   assert.strictEqual(clearIntervalMock.mock.callCount(), 1);
-  assert.deepStrictEqual(onStatus.mock.calls.at(-1).arguments, ['Screen capture ended']);
+  const finalScreenStatuses = onStatus.mock.calls
+    .map(call => call.arguments[0])
+    .filter(arg => arg && typeof arg === 'object' && 'screen' in arg);
+  assert.deepStrictEqual(finalScreenStatuses.at(-1), { screen: 'idle', message: 'Screen capture ended' });
 
   restoreTimers(origTimers);
 });
@@ -94,7 +101,10 @@ test('getDisplayMedia denial triggers onError', async () => {
   assert.ok(onError.mock.callCount() >= 1);
   assert.match(onError.mock.calls[0].arguments[0], /blocked or denied/);
   assert.ok(onStatus.mock.callCount() >= 1);
-  assert.deepStrictEqual(onStatus.mock.calls.at(-1).arguments, ['Screen capture ended']);
+  const statusPayloads = onStatus.mock.calls.map(call => call.arguments[0]);
+  assert.ok(statusPayloads.some(payload => payload?.screen === 'error'));
+  const finalStatus = statusPayloads.filter(payload => payload?.screen).at(-1);
+  assert.deepStrictEqual(finalStatus, { screen: 'idle', message: 'Screen capture ended' });
 
   restoreTimers(origTimers);
 });

--- a/src/utils/__tests__/statusIndicators.test.js
+++ b/src/utils/__tests__/statusIndicators.test.js
@@ -1,0 +1,153 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+function setupDom() {
+    const registry = new Map();
+
+    class MockShadowRoot {
+        appendChild() {}
+        querySelector() {
+            return null;
+        }
+    }
+
+    class MockHTMLElement {
+        constructor() {
+            this.shadowRoot = null;
+        }
+
+        attachShadow() {
+            this.shadowRoot = new MockShadowRoot();
+            return this.shadowRoot;
+        }
+
+        addEventListener() {}
+        removeEventListener() {}
+        dispatchEvent() {
+            return true;
+        }
+    }
+
+    const customElements = {
+        define(name, ctor) {
+            registry.set(name, ctor);
+        },
+        get(name) {
+            return registry.get(name);
+        },
+    };
+
+    const docEl = {
+        classList: {
+            add() {},
+            remove() {},
+        },
+    };
+
+    const document = {
+        documentElement: docEl,
+        body: {
+            appendChild() {},
+        },
+        createElement: () => ({ style: {} }),
+        createTreeWalker: () => ({ currentNode: null, nextNode: () => null }),
+        importNode: node => node,
+    };
+
+    globalThis.window = {
+        customElements,
+        HTMLElement: MockHTMLElement,
+        navigator: {},
+        document,
+    };
+    globalThis.document = document;
+    globalThis.HTMLElement = MockHTMLElement;
+    globalThis.customElements = customElements;
+    globalThis.ShadowRoot = MockShadowRoot;
+    globalThis.navigator = {};
+    globalThis.localStorage = {
+        _data: new Map(),
+        getItem(key) {
+            return this._data.has(key) ? this._data.get(key) : null;
+        },
+        setItem(key, value) {
+            this._data.set(key, String(value));
+        },
+        removeItem(key) {
+            this._data.delete(key);
+        },
+        clear() {
+            this._data.clear();
+        },
+    };
+
+    const raf = cb => setTimeout(() => cb(Date.now()), 16);
+    globalThis.requestAnimationFrame = raf;
+    window.requestAnimationFrame = raf;
+    globalThis.performance = { now: () => Date.now() };
+
+    return { registry };
+}
+
+function moduleUrl(relativePath) {
+    return pathToFileURL(path.join(__dirname, '..', '..', relativePath));
+}
+
+test('SalesWizardApp setStatus maps structured events to state flags', async () => {
+    setupDom();
+    const { SalesWizardApp } = await import(moduleUrl('components/app/SalesWizardApp.js'));
+    const app = new SalesWizardApp();
+
+    app.setStatus({ connection: 'connected', message: 'Live session connected' });
+    assert.strictEqual(app.connectionState, 'connected');
+    assert.strictEqual(app.connectionMessage, 'Live session connected');
+
+    app.setStatus({ audio: { state: 'capturing' } });
+    assert.strictEqual(app.audioState, 'capturing');
+    assert.strictEqual(app.audioMessage, 'Microphone streaming');
+
+    app.setStatus({ screen: { state: 'sharing', message: 'Screen capture active' } });
+    assert.strictEqual(app.screenState, 'sharing');
+    assert.strictEqual(app.screenMessage, 'Screen capture active');
+
+    app.setStatus('Screen capture ended');
+    assert.strictEqual(app.screenState, 'idle');
+    assert.strictEqual(app.statusText, 'Screen capture ended');
+
+    app.setStatus('WS error: timeout');
+    assert.strictEqual(app.connectionState, 'error');
+    assert.ok(app.connectionMessage.includes('WS error'));
+});
+
+test('AppHeader renders indicator templates with state attributes', async () => {
+    setupDom();
+    const { AppHeader } = await import(moduleUrl('components/app/AppHeader.js'));
+    const header = new AppHeader();
+
+    const connectionTemplate = header.renderIndicator({
+        type: 'connection',
+        state: 'connecting',
+        message: 'Opening WebSocket',
+    });
+    assert.strictEqual(connectionTemplate.values[0], 'connecting');
+    assert.strictEqual(connectionTemplate.values[1], 'connection');
+    assert.strictEqual(connectionTemplate.values[2], 'connecting');
+    assert.strictEqual(connectionTemplate.values[3], 'Opening WebSocket');
+
+    header.connectionState = 'connected';
+    header.connectionMessage = 'WS open';
+    header.audioState = 'capturing';
+    header.audioMessage = 'Listening';
+    header.screenState = 'sharing';
+    header.screenMessage = 'Screen active';
+
+    const groupTemplate = header.renderStatusIndicators();
+    const indicators = groupTemplate.values[0];
+    assert.strictEqual(indicators.length, 3);
+    const [connectionIndicator, audioIndicator, screenIndicator] = indicators;
+    assert.strictEqual(connectionIndicator.values[0], 'connected');
+    assert.strictEqual(audioIndicator.values[0], 'capturing');
+    assert.strictEqual(screenIndicator.values[0], 'sharing');
+});

--- a/src/utils/liveStreamer.js
+++ b/src/utils/liveStreamer.js
@@ -12,7 +12,7 @@ const logger = globalThis.logger || defaultLogger || console;
  *
  * @param {Object} opts
  * @param {(text:string)=>void} opts.onResponse Called when model emits text
- * @param {(status:string)=>void} [opts.onStatus] Status updates from client
+ * @param {(status:object|string)=>void} [opts.onStatus] Status updates from client
  * @param {(err:string)=>void} [opts.onError] Error messages
  * @param {(level:number)=>void} [opts.onAudioLevel] Receives audio level 0-1
  * @returns {Promise<()=>void>} resolves to a stop function
@@ -40,7 +40,13 @@ export async function startLiveStreaming({
       logger.warn('Error handling text:', err);
     }
   };
-  client.onStatus = onStatus;
+  client.onStatus = status => {
+    try {
+      onStatus(status);
+    } catch (_e) {
+      /* empty */
+    }
+  };
   client.onError = onError;
 
   await client.connect();
@@ -49,6 +55,7 @@ export async function startLiveStreaming({
   let audioStream; let audioCleanup = () => {};
   try {
     audioStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    onStatus({ audio: 'capturing', message: 'Microphone streaming' });
     const audioCtx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 16000 });
     const source = audioCtx.createMediaStreamSource(audioStream);
 
@@ -83,6 +90,7 @@ export async function startLiveStreaming({
         audioCleanup = () => {
           node.disconnect();
           cleanup();
+          onStatus({ audio: 'idle', message: 'Microphone idle' });
         };
       } catch (err) {
         console.warn('AudioWorklet init failed, falling back to ScriptProcessor:', err);
@@ -106,6 +114,7 @@ export async function startLiveStreaming({
         audioCleanup = () => {
           processor.disconnect();
           cleanup();
+          onStatus({ audio: 'idle', message: 'Microphone idle' });
         };
       }
     } else {
@@ -130,10 +139,12 @@ export async function startLiveStreaming({
       audioCleanup = () => {
         processor.disconnect();
         cleanup();
+        onStatus({ audio: 'idle', message: 'Microphone idle' });
       };
     }
   } catch (err) {
     logger.warn('Audio streaming failed to initialise:', err);
+    onStatus({ audio: 'error', message: `Audio streaming failed to initialise: ${err?.message || err}` });
   }
 
   // Screen capture
@@ -171,13 +182,14 @@ export async function startLiveStreaming({
       screenStream = null;
     }
     cleanupDomNodes();
-    onStatus('Screen capture ended');
+    onStatus({ screen: 'idle', message: 'Screen capture ended' });
   };
 
   try {
     screenStream = await navigator.mediaDevices.getDisplayMedia({ video: true });
     const track = screenStream.getVideoTracks()[0];
     track.onended = stopScreenCapture;
+    onStatus({ screen: 'sharing', message: 'Screen capture active' });
     const imageCapture = typeof ImageCapture === 'function' ? new ImageCapture(track) : null;
 
     const encodeBlobAndSend = async blob => {
@@ -356,6 +368,7 @@ export async function startLiveStreaming({
       : `Screen streaming failed to initialise: ${err?.message || err}`;
     logger.warn(msg, err);
     onError(msg);
+    onStatus({ screen: 'error', message: msg });
     stopScreenCapture();
   }
 


### PR DESCRIPTION
## Summary
- extend SalesWizardApp to normalize structured status payloads into connection, audio, and screen state flags with descriptive messages
- update AppHeader to replace the single status span with icon-based indicators and tooltips driven by the new state flags
- emit structured status events from LLMClient and liveStreamer and add unit tests for the status indicators and updated streaming status callbacks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7e6939f18833191fc27e9c37c2317