### PR TITLE
Handle live start handshake and client message flow

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ require("../src/utils/logger");
 const express = require('express');
 const { GoogleGenAI, Modality } = require('@google/genai');
 const { WebSocketServer } = require('ws');
+const { Blob } = require('buffer');
 const historyStore = require('./historyStore');
 
 const app = express();
@@ -116,29 +117,208 @@ const server = app.listen(process.env.PORT || 3001);
 
 // WebSocket endpoint for Gemini Live
 const wss = new WebSocketServer({ server, path: '/live' });
-wss.on('connection', async (ws) => {
-  const session = await genai.live.connect({
-    model: 'gemini-live-2.5-flash-preview',
-    config: { response_modalities: [Modality.TEXT], system_instruction: buildSystemInstruction() }
+wss.on('connection', (ws) => {
+  let liveSession = null;
+  let started = false;
+  let shuttingDown = false;
+
+  const now = () => new Date().toISOString();
+  const sendJSON = (payload) => {
+    try {
+      if (ws.readyState === ws.OPEN) {
+        ws.send(JSON.stringify(payload));
+      }
+    } catch (err) {
+      logger.error('Failed to send WS payload', err);
+    }
+  };
+
+  const sendStatus = (message, { terminal = false } = {}) =>
+    sendJSON({ type: 'status', message, terminal, ts: now() });
+  const sendError = (message, { terminal = false } = {}) =>
+    sendJSON({ type: 'error', message, terminal, ts: now() });
+  const sendText = (text) => sendJSON({ type: 'model_text', text });
+  const sendAudio = (data, mime) => sendJSON({ type: 'model_audio', data, mime });
+
+  const finalize = async (message, { sendTerminal = true } = {}) => {
+    if (shuttingDown) return;
+    if (sendTerminal) {
+      const terminalMessage = message || 'Session closed';
+      sendStatus(terminalMessage, { terminal: true });
+    }
+    shuttingDown = true;
+    try {
+      await liveSession?.close?.();
+    } catch (err) {
+      logger.error('Error closing live session', err);
+    }
+    try {
+      if (ws.readyState === ws.OPEN || ws.readyState === ws.CLOSING) {
+        ws.close();
+      }
+    } catch (err) {
+      logger.error('Error closing WebSocket', err);
+    }
+  };
+
+  const normalizeModalities = (modalities) => {
+    if (!Array.isArray(modalities) || modalities.length === 0) {
+      return [Modality.TEXT];
+    }
+    return modalities.map((mod) => {
+      if (typeof mod === 'string' && Modality[mod]) {
+        return Modality[mod];
+      }
+      return mod;
+    });
+  };
+
+  const forwardServerMessage = (message) => {
+    try {
+      const text = typeof message?.text === 'string' ? message.text : '';
+      if (text) {
+        sendText(text);
+      }
+
+      const parts = message?.serverContent?.modelTurn?.parts || [];
+      for (const part of parts) {
+        const inline = part?.inlineData;
+        if (inline?.mimeType?.startsWith('audio/') && inline.data) {
+          try {
+            let buffer;
+            if (typeof inline.data === 'string') {
+              buffer = Buffer.from(inline.data, 'base64');
+            } else if (inline.data instanceof Uint8Array || Buffer.isBuffer(inline.data)) {
+              buffer = Buffer.from(inline.data);
+            }
+            if (buffer && buffer.length) {
+              sendAudio(buffer.toString('base64'), inline.mimeType);
+            }
+          } catch (err) {
+            logger.error('Failed to forward audio chunk', err);
+          }
+        }
+      }
+    } catch (err) {
+      logger.error('Error forwarding Gemini message', err);
+    }
+  };
+
+  sendStatus('Connected to live gateway. Awaiting start command.');
+
+  ws.on('message', async (raw) => {
+    if (shuttingDown) return;
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch (err) {
+      logger.warn('Discarding invalid JSON payload', err);
+      sendError('Invalid JSON payload');
+      return;
+    }
+
+    if (!started) {
+      if (msg?.type !== 'start') {
+        sendError('First message must be a start command', { terminal: true });
+        await finalize('Session terminated: start command missing');
+        return;
+      }
+
+      started = true;
+      const model = typeof msg.model === 'string' && msg.model.trim() ? msg.model.trim() : 'gemini-2.0-flash-live-001';
+      const systemInstruction = msg.systemInstruction || buildSystemInstruction();
+      const responseModalities = normalizeModalities(msg.responseModalities);
+
+      sendStatus(`Starting Gemini live session on ${model}...`);
+
+      try {
+        liveSession = await genai.live.connect({
+          model,
+          config: {
+            responseModalities,
+            systemInstruction: systemInstruction ? { parts: [{ text: systemInstruction }] } : undefined,
+          },
+          httpOptions: { apiVersion: 'v1alpha' },
+          callbacks: {
+            onopen: () => sendStatus('Gemini live session established'),
+            onmessage: forwardServerMessage,
+            onerror: (err) => {
+              logger.error('Gemini live error', err);
+              sendError(`Gemini live error: ${err?.message || err}`);
+            },
+            onclose: (evt) => {
+              const reason = evt?.reason ? `Gemini live closed: ${evt.reason}` : 'Gemini live closed';
+              finalize(reason).catch((closeErr) => logger.error('Error during live finalize', closeErr));
+            },
+          },
+        });
+
+        sendStatus(`Live session ready on model ${model}`);
+      } catch (err) {
+        logger.error('Failed to start live session', err);
+        sendError('Failed to start live session', { terminal: true });
+        await finalize('Session terminated: Gemini live start failure');
+      }
+      return;
+    }
+
+    if (!liveSession) {
+      sendError('Live session not initialized');
+      return;
+    }
+
+    switch (msg.type) {
+      case 'text':
+        if (typeof msg.text === 'string' && msg.text.trim()) {
+          try {
+            await liveSession.sendClientContent({
+              turns: [{ parts: [{ text: msg.text }] }],
+            });
+          } catch (err) {
+            logger.error('Failed to forward text input', err);
+            sendError('Failed to send text to Gemini');
+          }
+        }
+        break;
+      case 'audio':
+        if (typeof msg.data === 'string' && msg.data) {
+          try {
+            const bytes = Buffer.from(msg.data, 'base64');
+            const blob = new Blob([bytes], { type: msg.mime || 'audio/pcm;rate=16000' });
+            liveSession.sendRealtimeInput({ media: blob });
+          } catch (err) {
+            logger.error('Failed to forward audio input', err);
+            sendError('Failed to send audio to Gemini');
+          }
+        }
+        break;
+      case 'image':
+        if (typeof msg.data === 'string' && msg.data) {
+          try {
+            const bytes = Buffer.from(msg.data, 'base64');
+            const blob = new Blob([bytes], { type: msg.mime || 'image/jpeg' });
+            liveSession.sendRealtimeInput({ media: blob });
+          } catch (err) {
+            logger.error('Failed to forward image input', err);
+            sendError('Failed to send image to Gemini');
+          }
+        }
+        break;
+      case 'end':
+        await finalize('Session ended by client');
+        break;
+      default:
+        sendError(`Unsupported message type: ${msg.type}`);
+        break;
+    }
   });
 
-  // Forward Gemini replies back to the client
-  (async () => {
-    for await (const response of session.receive()) {
-      ws.send(JSON.stringify({ text: response.text || '' }));
-    }
-  })();
-
-  ws.on('message', async (msg) => {
-    const data = JSON.parse(msg);
-    if (data.audio) {
-      const buf = Buffer.from(data.audio, 'base64');
-      await session.send_realtime_input({ audio: { data: buf, mime_type: data.mimeType || 'audio/pcm;rate=16000' } });
-    } else if (data.image) {
-      const buf = Buffer.from(data.image, 'base64');
-      await session.send_realtime_input({ image: { data: buf, mime_type: data.mimeType || 'image/jpeg' } });
+  ws.on('close', async () => {
+    shuttingDown = true;
+    try {
+      await liveSession?.close?.();
+    } catch (err) {
+      logger.error('Error closing live session after socket close', err);
     }
   });
-
-  ws.on('close', () => session.close());
 });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "make": "node -r dotenv/config node_modules/.bin/electron-forge make",
     "publish": "node -r dotenv/config node_modules/.bin/electron-forge publish",
     "lint": "eslint .",
-    "test": "node -r ./src/utils/logger.js --test src/utils/__tests__/*.test.js",
+    "test": "node -r ./src/utils/logger.js --test src/utils/__tests__/*.test.js src/services/__tests__/*.test.js",
     "format": "prettier --write ."
   },
   "keywords": [

--- a/src/services/__tests__/llmClient.test.js
+++ b/src/services/__tests__/llmClient.test.js
@@ -1,0 +1,119 @@
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances = [];
+
+  constructor(url) {
+    this.url = url;
+    this.readyState = FakeWebSocket.CONNECTING;
+    this.sent = [];
+    FakeWebSocket.instances.push(this);
+    setImmediate(() => {
+      if (this.readyState === FakeWebSocket.CONNECTING) {
+        this.readyState = FakeWebSocket.OPEN;
+        this.onopen?.();
+      }
+    });
+  }
+
+  send(payload) {
+    this.sent.push(JSON.parse(payload));
+  }
+
+  close() {
+    if (this.readyState === FakeWebSocket.CLOSED) return;
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.({ code: 1000, reason: 'client close' });
+  }
+
+  static latest() {
+    return FakeWebSocket.instances.at(-1) || null;
+  }
+
+  static reset() {
+    FakeWebSocket.instances = [];
+  }
+}
+
+before(() => {
+  FakeWebSocket.reset();
+  global.WebSocket = FakeWebSocket;
+});
+
+after(() => {
+  delete global.WebSocket;
+  FakeWebSocket.reset();
+});
+
+test('LLMClient sends start handshake on connect', async () => {
+  FakeWebSocket.reset();
+  const { LLMClient } = await import('../../services/llmClient.js');
+  const client = new LLMClient({ url: 'ws://example.test' });
+  const statuses = [];
+  client.onStatus = (msg) => statuses.push(msg);
+
+  await client.connect({ model: 'custom-model', responseModalities: ['TEXT'], systemInstruction: 'sys' });
+  const ws = FakeWebSocket.latest();
+
+  assert.ok(ws, 'websocket created');
+  assert.deepStrictEqual(ws.sent[0], {
+    type: 'start',
+    model: 'custom-model',
+    responseModalities: ['TEXT'],
+    systemInstruction: 'sys',
+  });
+  assert.ok(statuses.includes('WS open'));
+});
+
+test('LLMClient routes inbound messages to callbacks', async () => {
+  FakeWebSocket.reset();
+  const { LLMClient } = await import('../../services/llmClient.js');
+  const client = new LLMClient({ url: 'ws://example.test' });
+
+  const statuses = [];
+  const texts = [];
+  const audios = [];
+  const errors = [];
+
+  client.onStatus = (msg, payload) => statuses.push({ msg, payload });
+  client.onText = (text) => texts.push(text);
+  client.onAudio = (data, mime) => audios.push({ data, mime });
+  client.onError = (msg) => errors.push(msg);
+
+  await client.connect();
+  const ws = FakeWebSocket.latest();
+  assert.ok(ws);
+
+  ws.onmessage?.({ data: JSON.stringify({ type: 'status', message: 'connected', terminal: false }) });
+  ws.onmessage?.({ data: JSON.stringify({ type: 'model_text', text: 'hello' }) });
+  ws.onmessage?.({ data: JSON.stringify({ type: 'model_audio', data: 'Zg==', mime: 'audio/wav' }) });
+  ws.onmessage?.({ data: JSON.stringify({ type: 'error', message: 'fail' }) });
+
+  const relevantStatuses = statuses.filter(({ msg }) => msg !== 'WS open');
+  assert.deepStrictEqual(relevantStatuses, [
+    { msg: 'connected', payload: { type: 'status', message: 'connected', terminal: false } },
+  ]);
+  assert.deepStrictEqual(texts, ['hello']);
+  assert.deepStrictEqual(audios, [{ data: 'Zg==', mime: 'audio/wav' }]);
+  assert.deepStrictEqual(errors, ['fail']);
+});
+
+test('LLMClient end sends termination control message', async () => {
+  FakeWebSocket.reset();
+  const { LLMClient } = await import('../../services/llmClient.js');
+  const client = new LLMClient({ url: 'ws://example.test' });
+
+  await client.connect();
+  const ws = FakeWebSocket.latest();
+  assert.ok(ws);
+
+  client.end();
+  assert.deepStrictEqual(ws.sent.at(-1), { type: 'end' });
+  assert.strictEqual(ws.readyState, FakeWebSocket.CLOSED);
+});
+

--- a/src/services/__tests__/llmClient.test.js
+++ b/src/services/__tests__/llmClient.test.js
@@ -108,6 +108,9 @@ test('LLMClient end sends termination control message', async () => {
   const { LLMClient } = await import('../../services/llmClient.js');
   const client = new LLMClient({ url: 'ws://example.test' });
 
+  const statuses = [];
+  client.onStatus = (msg, payload) => statuses.push({ msg, payload });
+
   await client.connect();
   const ws = FakeWebSocket.latest();
   assert.ok(ws);
@@ -115,5 +118,40 @@ test('LLMClient end sends termination control message', async () => {
   client.end();
   assert.deepStrictEqual(ws.sent.at(-1), { type: 'end' });
   assert.strictEqual(ws.readyState, FakeWebSocket.CLOSED);
+  assert.deepStrictEqual(statuses.at(-1), {
+    msg: 'WS closed',
+    payload: {
+      connection: 'disconnected',
+      code: 1000,
+      reason: 'client close',
+      terminal: true,
+      message: 'WS closed',
+    },
+  });
+});
+
+test('LLMClient surfaces parse failures and unknown payload types', async () => {
+  FakeWebSocket.reset();
+  const { LLMClient } = await import('../../services/llmClient.js');
+  const client = new LLMClient({ url: 'ws://example.test' });
+
+  const errors = [];
+  const statuses = [];
+  client.onError = (message, payload) => errors.push({ message, payload });
+  client.onStatus = (msg, payload) => statuses.push({ msg, payload });
+
+  await client.connect();
+  const ws = FakeWebSocket.latest();
+  assert.ok(ws);
+
+  ws.onmessage?.({ data: '{' });
+  ws.onmessage?.({ data: JSON.stringify({ type: 'custom', foo: 'bar' }) });
+
+  assert.strictEqual(errors.at(-1)?.message, 'Failed to parse message');
+  assert.strictEqual(errors.at(-1)?.payload?.raw, '{');
+  assert.deepStrictEqual(statuses.at(-1), {
+    msg: 'Unhandled message',
+    payload: { type: 'custom', foo: 'bar', message: 'Unhandled message' },
+  });
 });
 

--- a/src/services/llmClient.js
+++ b/src/services/llmClient.js
@@ -10,9 +10,9 @@ export class LLMClient {
     ws = null;
     /** @type {(txt:string)=>void} */
     onText = () => {};
-    /** @type {(s:string)=>void} */
+    /** @type {(status:string,payload?:Record<string,unknown>)=>void} */
     onStatus = () => {};
-    /** @type {(e:string)=>void} */
+    /** @type {(message:string,payload?:unknown)=>void} */
     onError = () => {};
     /** @type {(data:string,mime:string)=>void} */
     onAudio = () => {};
@@ -30,11 +30,7 @@ export class LLMClient {
                     if (!opened) {
                         const msg = 'WS open timeout';
                         this.onError(msg);
-                        try {
-                            this.ws?.close();
-                        } catch (e) {
-                            /* empty */
-                        }
+                        this._safeClose();
                         reject(new Error(msg));
                     }
                 }, 10_000);
@@ -42,18 +38,20 @@ export class LLMClient {
                 this.ws.onopen = () => {
                     opened = true;
                     clearTimeout(timeout);
-                    const instr = systemInstruction || this._buildSystemInstruction();
+                    const instr = systemInstruction ?? this._buildSystemInstruction();
                     this._send({
                         type: 'start',
                         model,
                         responseModalities,
                         systemInstruction: instr,
                     });
-                    this.onStatus('WS open', { open: true });
+                    this._emitStatus('WS open', { connection: 'connected', open: true });
                     resolve(true);
                 };
+
                 this.ws.onclose = evt => {
-                    this.onStatus('WS closed', {
+                    this._emitStatus('WS closed', {
+                        connection: 'disconnected',
                         code: evt?.code,
                         reason: evt?.reason,
                         terminal: true,
@@ -65,24 +63,21 @@ export class LLMClient {
                         reject(new Error(msg));
                     }
                 };
+
                 this.ws.onerror = e => {
                     const msg = `WS error: ${e?.message || String(e)}`;
+                    this._emitStatus('WS error', { connection: 'error', error: e, message: msg });
                     this.onError(msg, e);
                     if (!opened) {
                         clearTimeout(timeout);
                         reject(new Error(msg));
                     }
                 };
+
                 this.ws.onmessage = evt => {
-                    try {
-                        const msg = JSON.parse(evt.data);
-                        if (msg.type === 'status') this.onStatus(msg.message ?? msg.msg ?? '', msg);
-                        else if (msg.type === 'error') this.onError(msg.message ?? msg.msg ?? 'Unknown error', msg);
-                        else if (msg.type === 'model_text' && typeof msg.text === 'string') this.onText(msg.text);
-                        else if (msg.type === 'model_audio' && typeof msg.data === 'string') this.onAudio(msg.data, msg.mime || 'audio/pcm;rate=16000');
-                    } catch (e) {
-                        /* empty */
-                    }
+                    const parsed = this._safeParse(evt?.data);
+                    if (!parsed) return;
+                    this._handleIncoming(parsed);
                 };
             } catch (e) {
                 reject(e);
@@ -116,6 +111,56 @@ export class LLMClient {
         }
     }
 
+    _emitStatus(message, payload = {}) {
+        try {
+            this.onStatus(message, { ...payload, message });
+        } catch (e) {
+            /* empty */
+        }
+    }
+
+    _safeParse(raw) {
+        if (!raw) return null;
+        try {
+            return typeof raw === 'string' ? JSON.parse(raw) : JSON.parse(String(raw));
+        } catch (e) {
+            this.onError('Failed to parse message', { raw, error: e });
+            return null;
+        }
+    }
+
+    _handleIncoming(msg) {
+        switch (msg?.type) {
+            case 'status':
+                this._emitStatus(msg.message ?? msg.msg ?? '', msg);
+                break;
+            case 'error':
+                this.onError(msg.message ?? msg.msg ?? 'Unknown error', msg);
+                break;
+            case 'model_text':
+                if (typeof msg.text === 'string') {
+                    this.onText(msg.text);
+                }
+                break;
+            case 'model_audio':
+                if (typeof msg.data === 'string') {
+                    this.onAudio(msg.data, msg.mime || 'audio/pcm;rate=16000');
+                }
+                break;
+            default:
+                this._emitStatus('Unhandled message', msg || {});
+                break;
+        }
+    }
+
+    _safeClose() {
+        try {
+            this.ws?.close();
+        } catch (e) {
+            /* empty */
+        }
+    }
+
     sendText(text) {
         this._send({ type: 'text', text });
     }
@@ -130,10 +175,6 @@ export class LLMClient {
 
     end() {
         this._send({ type: 'end' });
-        try {
-            this.ws?.close();
-        } catch (e) {
-            /* empty */
-        }
+        this._safeClose();
     }
 }

--- a/src/services/llmClient.js
+++ b/src/services/llmClient.js
@@ -49,11 +49,15 @@ export class LLMClient {
                         responseModalities,
                         systemInstruction: instr,
                     });
-                    this.onStatus('WS open');
+                    this.onStatus('WS open', { open: true });
                     resolve(true);
                 };
-                this.ws.onclose = () => {
-                    this.onStatus('WS closed');
+                this.ws.onclose = evt => {
+                    this.onStatus('WS closed', {
+                        code: evt?.code,
+                        reason: evt?.reason,
+                        terminal: true,
+                    });
                     if (!opened) {
                         clearTimeout(timeout);
                         const msg = 'WS closed before open';
@@ -63,7 +67,7 @@ export class LLMClient {
                 };
                 this.ws.onerror = e => {
                     const msg = `WS error: ${e?.message || String(e)}`;
-                    this.onError(msg);
+                    this.onError(msg, e);
                     if (!opened) {
                         clearTimeout(timeout);
                         reject(new Error(msg));
@@ -72,10 +76,10 @@ export class LLMClient {
                 this.ws.onmessage = evt => {
                     try {
                         const msg = JSON.parse(evt.data);
-                        if (msg.type === 'status') this.onStatus(msg.msg);
-                        else if (msg.type === 'error') this.onError(msg.msg);
-                        else if (msg.type === 'model_text') this.onText(msg.text);
-                        else if (msg.type === 'model_audio') this.onAudio(msg.data, msg.mime);
+                        if (msg.type === 'status') this.onStatus(msg.message ?? msg.msg ?? '', msg);
+                        else if (msg.type === 'error') this.onError(msg.message ?? msg.msg ?? 'Unknown error', msg);
+                        else if (msg.type === 'model_text' && typeof msg.text === 'string') this.onText(msg.text);
+                        else if (msg.type === 'model_audio' && typeof msg.data === 'string') this.onAudio(msg.data, msg.mime || 'audio/pcm;rate=16000');
                     } catch (e) {
                         /* empty */
                     }


### PR DESCRIPTION
## Summary
- require a start command to configure Gemini live sessions, stream status/model events, and send terminal updates on close
- update the browser LLM client to consume the new payload schema and surface richer status/error metadata
- add service-layer unit tests for the WebSocket client and run them via the npm test script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7e693cdd483319c8e4cda8d6b8050