### PR TITLE
Refactor notes workflow to structured entries

### DIFF
--- a/backend/historyStore.js
+++ b/backend/historyStore.js
@@ -33,6 +33,27 @@ function saveHistory(history) {
     }
 }
 
+function normalizeStructuredNotes(notes) {
+    if (!Array.isArray(notes)) return null;
+    const now = Date.now();
+    return notes
+        .map(note => {
+            if (!note) return null;
+            if (typeof note === 'string') {
+                const trimmed = note.trim();
+                if (!trimmed) return null;
+                return { text: trimmed, type: 'manual', timestamp: now };
+            }
+            if (typeof note !== 'object') return null;
+            const text = typeof note.text === 'string' ? note.text.trim() : '';
+            if (!text) return null;
+            const timestamp = typeof note.timestamp === 'number' ? note.timestamp : now;
+            const type = typeof note.type === 'string' && note.type ? note.type : 'auto';
+            return { ...note, text, type, timestamp };
+        })
+        .filter(Boolean);
+}
+
 function appendTurn(sessionId, data) {
     const history = loadHistory();
     let session = history.sessions[sessionId];
@@ -41,13 +62,36 @@ function appendTurn(sessionId, data) {
             id: sessionId,
             timestamp: data.timestamp || Date.now(),
             conversationHistory: [],
-            notes: data.notes || '',
+            notes: normalizeStructuredNotes(data.notes) || [],
+            manualNotes:
+                typeof data.manualNotes === 'string'
+                    ? data.manualNotes
+                    : typeof data.notes === 'string'
+                    ? data.notes
+                    : '',
         };
         history.sessions[sessionId] = session;
+    } else {
+        if (!Array.isArray(session.notes)) {
+            session.notes = normalizeStructuredNotes(session.notes) || [];
+        }
+        if (typeof session.manualNotes !== 'string') {
+            session.manualNotes = '';
+        }
+        if (typeof session.notes === 'string') {
+            session.manualNotes = session.notes;
+            session.notes = [];
+        }
     }
 
-    if (typeof data.notes === 'string') {
-        session.notes = data.notes;
+    if (Array.isArray(data.notes)) {
+        session.notes = normalizeStructuredNotes(data.notes) || [];
+    } else if (typeof data.notes === 'string' && typeof data.manualNotes !== 'string') {
+        session.manualNotes = data.notes;
+    }
+
+    if (typeof data.manualNotes === 'string') {
+        session.manualNotes = data.manualNotes;
     }
 
     if (!data.sessionStart && (data.transcription || data.ai_response)) {

--- a/src/components/app/SalesWizardApp.js
+++ b/src/components/app/SalesWizardApp.js
@@ -147,7 +147,7 @@ export class SalesWizardApp extends LitElement {
         sessionId: { type: String },
         transcripts: { type: Array },
         notes: { type: Array },
-        noteText: { type: String },
+        manualNotes: { type: String },
         _viewInstances: { type: Object, state: true },
         _isClickThrough: { state: true },
         _awaitingNewResponse: { state: true },
@@ -178,7 +178,7 @@ export class SalesWizardApp extends LitElement {
         this.sessionId = null;
         this.transcripts = [];
         this.notes = [];
-        this.noteText = '';
+        this.manualNotes = '';
         this.audioLevel = 0;
 
         // Apply layout mode to document root
@@ -235,7 +235,8 @@ export class SalesWizardApp extends LitElement {
                                 body: JSON.stringify({
                                     transcription: transcript,
                                     ai_response: data.reply,
-                                    notes: this.noteText,
+                                    notes: this.notes,
+                                    manualNotes: this.manualNotes,
                                 }),
                             });
                         } catch (err) {
@@ -262,7 +263,17 @@ export class SalesWizardApp extends LitElement {
             },
             onNote: note => {
                 if (note) {
-                    this.notes = [...this.notes, note];
+                    const normalizedNote = {
+                        ...note,
+                        type: note.type || 'auto',
+                        text: typeof note.text === 'string' ? note.text : '',
+                        timestamp:
+                            typeof note.timestamp === 'number'
+                                ? note.timestamp
+                                : Date.now(),
+                    };
+                    this.notes = [...this.notes, normalizedNote];
+                    this.persistNotes();
                     this.requestUpdate();
                 }
             },
@@ -426,12 +437,16 @@ export class SalesWizardApp extends LitElement {
         this.sessionId = self.crypto?.randomUUID?.() ?? Date.now().toString();
         this.transcripts = [];
         this.notes = [];
-        this.noteText = '';
+        this.manualNotes = '';
         try {
             await fetch(`${API_BASE}/history/${this.sessionId}/turn`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ sessionStart: true, notes: '' }),
+                body: JSON.stringify({
+                    sessionStart: true,
+                    notes: this.notes,
+                    manualNotes: this.manualNotes,
+                }),
             });
         } catch (error) {
             logger.error('Failed to start session history:', error);
@@ -493,15 +508,33 @@ export class SalesWizardApp extends LitElement {
         }
     }
 
-    async handleNotesChange(e) {
+    async handleManualNotesChange(e) {
         const newNotes = e?.detail?.value ?? e?.target?.value ?? '';
-        this.noteText = newNotes;
+        this.manualNotes = newNotes;
+        await this.persistNotes();
+    }
+
+    async handleStructuredNotesChange(e) {
+        const updatedNotes = Array.isArray(e?.detail?.notes) ? e.detail.notes : [];
+        this.notes = updatedNotes.map(note => ({
+            ...note,
+            type: note.type || 'auto',
+            text: typeof note.text === 'string' ? note.text : '',
+            timestamp: typeof note.timestamp === 'number' ? note.timestamp : Date.now(),
+        }));
+        await this.persistNotes();
+    }
+
+    async persistNotes() {
         if (!this.sessionId) return;
         try {
             await fetch(`${API_BASE}/history/${this.sessionId}/turn`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ notes: this.noteText }),
+                body: JSON.stringify({
+                    notes: this.notes,
+                    manualNotes: this.manualNotes,
+                }),
             });
         } catch (error) {
             logger.error('Failed to save notes:', error);
@@ -619,10 +652,12 @@ export class SalesWizardApp extends LitElement {
                             }}
                         ></assistant-view>
                         <side-panel
-                            .notes=${this.noteText}
+                            .structuredNotes=${this.notes}
+                            .manualNotes=${this.manualNotes}
                             .transcripts=${this.transcripts}
                             .selectedProfile=${this.selectedProfile}
-                            @notes-change=${e => this.handleNotesChange(e)}
+                            @manual-notes-change=${e => this.handleManualNotesChange(e)}
+                            @structured-notes-change=${e => this.handleStructuredNotesChange(e)}
                         ></side-panel>
                     </div>
                 `;

--- a/src/components/app/SidePanel.js
+++ b/src/components/app/SidePanel.js
@@ -28,12 +28,24 @@ export class SidePanel extends LitElement {
             box-shadow: var(--glass-edge-highlight, inset 0 1px 0 rgba(255, 255, 255, 0.35));
         }
 
-        .transcripts {
+        .content {
             flex: 1;
             overflow-y: auto;
             padding: var(--main-content-padding);
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
             background: var(--panel-surface-background, rgba(255, 255, 255, 0.02));
             backdrop-filter: inherit;
+        }
+
+        .section-title {
+            font-size: 13px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            margin-bottom: 12px;
+            color: var(--subtle-text-color, rgba(255, 255, 255, 0.7));
         }
 
         .transcript-item:not(:last-child) {
@@ -49,51 +61,118 @@ export class SidePanel extends LitElement {
             line-height: 1.4;
         }
 
-        .notes {
-            flex: 0 0 auto;
+        .structured-notes-list {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .structured-note {
+            border: 1px solid var(--glass-border, var(--border-color));
+            border-radius: 8px;
+            padding: 10px;
+            background: var(--panel-card-background, rgba(8, 12, 24, 0.25));
+            backdrop-filter: var(--glass-backdrop-filter, blur(22px) saturate(150%));
+            -webkit-backdrop-filter: var(--glass-backdrop-filter, blur(22px) saturate(150%));
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .structured-note .note-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 12px;
+            color: var(--subtle-text-color, rgba(255, 255, 255, 0.65));
+        }
+
+        .note-type {
+            text-transform: capitalize;
+            font-weight: 600;
+            padding: 2px 6px;
+            border-radius: 999px;
+            background: var(--chip-background, rgba(255, 255, 255, 0.08));
+        }
+
+        .note-text {
+            font-size: 14px;
+            line-height: 1.5;
+            white-space: pre-wrap;
+        }
+
+        .note-actions,
+        .note-edit-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 8px;
+        }
+
+        .note-button {
+            background: var(--button-background, rgba(255, 255, 255, 0.08));
+            color: inherit;
+            border: 1px solid var(--glass-border, var(--border-color));
+            padding: 4px 10px;
+            border-radius: 4px;
+            font-size: 12px;
+            cursor: pointer;
+            transition: background 0.15s ease;
+        }
+
+        .note-button:hover {
+            background: var(--hover-background, rgba(255, 255, 255, 0.16));
+        }
+
+        .note-button.primary {
+            background: var(--accent-color, rgba(66, 133, 244, 0.24));
+            border-color: var(--accent-color, rgba(66, 133, 244, 0.4));
+        }
+
+        .note-button.destructive {
+            color: var(--danger-color, #ff6b6b);
+            border-color: rgba(255, 107, 107, 0.4);
+        }
+
+        .note-editor {
+            width: 100%;
+            min-height: 80px;
+            padding: 8px;
+            border-radius: 6px;
+            border: 1px solid var(--glass-border, var(--border-color));
+            background: var(--panel-input-background, var(--input-background));
+            color: inherit;
+            font-size: 14px;
+            font-family: inherit;
+            resize: vertical;
+        }
+
+        .note-editor:focus {
+            outline: none;
+            border-color: var(--focus-border-color);
+            box-shadow: 0 0 0 2px var(--focus-box-shadow);
+        }
+
+        .note-type-select {
+            background: var(--button-background, rgba(255, 255, 255, 0.08));
+            color: inherit;
+            border: 1px solid var(--glass-border, var(--border-color));
+            border-radius: 4px;
+            font-size: 12px;
+            padding: 4px 6px;
+        }
+
+        .manual-notes {
             border-top: 1px solid var(--glass-border, var(--border-color));
             padding: var(--main-content-padding);
             background: var(--panel-footer-background, rgba(255, 255, 255, 0.04));
             backdrop-filter: inherit;
-        }
-
-        .notes-actions {
             display: flex;
-            justify-content: flex-end;
-            margin-top: 8px;
-            gap: 8px;
+            flex-direction: column;
+            gap: 12px;
         }
 
-        .save-button {
-            background: var(--button-background);
-            color: var(--text-color);
-            border: 1px solid var(--glass-border, var(--button-border));
-            padding: 4px 8px;
-            border-radius: 4px;
-            font-size: 12px;
-            cursor: pointer;
-            backdrop-filter: var(--glass-backdrop-filter, blur(22px) saturate(150%));
-            -webkit-backdrop-filter: var(--glass-backdrop-filter, blur(22px) saturate(150%));
-        }
-
-        .save-button:hover {
-            background: var(--hover-background);
-        }
-
-        .format-select {
-            background: var(--button-background);
-            color: var(--text-color);
-            border: 1px solid var(--glass-border, var(--button-border));
-            padding: 4px 6px;
-            border-radius: 4px;
-            font-size: 12px;
-            backdrop-filter: var(--glass-backdrop-filter, blur(22px) saturate(150%));
-            -webkit-backdrop-filter: var(--glass-backdrop-filter, blur(22px) saturate(150%));
-        }
-
-        textarea {
+        .manual-notes textarea {
             width: 100%;
-            height: 100%;
             min-height: 120px;
             padding: 10px;
             background: var(--panel-input-background, var(--input-background));
@@ -107,38 +186,91 @@ export class SidePanel extends LitElement {
             -webkit-backdrop-filter: var(--glass-backdrop-filter, blur(22px) saturate(150%));
         }
 
-        textarea::placeholder {
-            color: var(--placeholder-color);
-        }
-
-        textarea:focus {
+        .manual-notes textarea:focus {
             outline: none;
             border-color: var(--focus-border-color);
             box-shadow: 0 0 0 2px var(--focus-box-shadow);
             background: var(--input-focus-background);
         }
+
+        .notes-actions {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .notes-actions select {
+            flex: 1;
+            background: var(--button-background, rgba(255, 255, 255, 0.08));
+            color: var(--text-color);
+            border: 1px solid var(--glass-border, var(--button-border));
+            padding: 6px 8px;
+            border-radius: 4px;
+            font-size: 12px;
+        }
+
+        .save-button {
+            background: var(--button-background);
+            color: var(--text-color);
+            border: 1px solid var(--glass-border, var(--button-border));
+            padding: 6px 12px;
+            border-radius: 4px;
+            font-size: 12px;
+            cursor: pointer;
+            white-space: nowrap;
+        }
+
+        .save-button:hover {
+            background: var(--hover-background);
+        }
+
+        .empty-state {
+            font-size: 13px;
+            color: var(--subtle-text-color, rgba(255, 255, 255, 0.6));
+            border: 1px dashed var(--glass-border, rgba(255, 255, 255, 0.1));
+            border-radius: 8px;
+            padding: 12px;
+            text-align: center;
+        }
     `;
 
     static properties = {
         transcripts: { type: Array },
-        notes: { type: String },
+        structuredNotes: { type: Array },
+        manualNotes: { type: String },
         selectedProfile: { type: String },
         exportFormat: { type: String },
+        _editingNoteId: { state: true },
+        _draftNote: { state: true },
     };
 
     constructor() {
         super();
         this.transcripts = [];
-        this.notes = '';
+        this.structuredNotes = [];
+        this.manualNotes = '';
         this.selectedProfile = 'interview';
         this.exportFormat = 'json';
+        this._editingNoteId = null;
+        this._draftNote = null;
     }
 
-    _onNotesChange(e) {
-        this.notes = e.target.value;
+    _dispatchStructuredNotes(notes) {
         this.dispatchEvent(
-            new CustomEvent('notes-change', {
-                detail: { value: this.notes },
+            new CustomEvent('structured-notes-change', {
+                detail: { notes },
+                bubbles: true,
+                composed: true,
+            })
+        );
+    }
+
+    _onManualNotesChange(e) {
+        this.manualNotes = e.target.value;
+        this.dispatchEvent(
+            new CustomEvent('manual-notes-change', {
+                detail: { value: this.manualNotes },
                 bubbles: true,
                 composed: true,
             })
@@ -154,7 +286,8 @@ export class SidePanel extends LitElement {
         try {
             const res = await window.electron.exportSession({
                 format: this.exportFormat,
-                notes: this.notes,
+                structuredNotes: this.structuredNotes,
+                manualNotes: this.manualNotes,
                 profile: this.selectedProfile,
             });
             if (res?.success) {
@@ -172,30 +305,162 @@ export class SidePanel extends LitElement {
         }
     }
 
-    render() {
+    _formatTimestamp(timestamp) {
+        if (typeof timestamp !== 'number') return '—';
+        try {
+            return new Date(timestamp).toLocaleString();
+        } catch {
+            return '—';
+        }
+    }
+
+    _resolveNoteId(note, index) {
+        if (note?.id) return note.id;
+        const base = typeof note?.timestamp === 'number' ? note.timestamp : Date.now();
+        return `${base}-${index}`;
+    }
+
+    _startEdit(note, index) {
+        const id = this._resolveNoteId(note, index);
+        this._editingNoteId = id;
+        this._draftNote = {
+            id,
+            text: note?.text || '',
+            type: note?.type || 'auto',
+            timestamp: typeof note?.timestamp === 'number' ? note.timestamp : Date.now(),
+        };
+    }
+
+    _cancelEdit() {
+        this._editingNoteId = null;
+        this._draftNote = null;
+    }
+
+    _onDraftTextChange(e) {
+        if (!this._draftNote) return;
+        this._draftNote = { ...this._draftNote, text: e.target.value };
+    }
+
+    _onDraftTypeChange(e) {
+        if (!this._draftNote) return;
+        this._draftNote = { ...this._draftNote, type: e.target.value };
+    }
+
+    _saveDraft(id) {
+        if (!this._draftNote || id !== this._editingNoteId) return;
+        const text = (this._draftNote.text || '').trim();
+        if (!text) {
+            this._deleteNote(id);
+            return;
+        }
+        const updatedNotes = this.structuredNotes.map((note, index) => {
+            const noteId = this._resolveNoteId(note, index);
+            if (noteId !== id) return note;
+            return {
+                ...note,
+                text,
+                type: this._draftNote.type || 'auto',
+                timestamp:
+                    typeof this._draftNote.timestamp === 'number'
+                        ? this._draftNote.timestamp
+                        : note.timestamp || Date.now(),
+            };
+        });
+        this.structuredNotes = updatedNotes;
+        this._dispatchStructuredNotes(updatedNotes);
+        this._cancelEdit();
+    }
+
+    _deleteNote(id) {
+        const updatedNotes = this.structuredNotes.filter((note, index) => this._resolveNoteId(note, index) !== id);
+        this.structuredNotes = updatedNotes;
+        this._dispatchStructuredNotes(updatedNotes);
+        if (this._editingNoteId === id) {
+            this._cancelEdit();
+        }
+    }
+
+    _renderStructuredNote(note, index) {
+        const id = this._resolveNoteId(note, index);
+        const isEditing = this._editingNoteId === id;
+        const displayText = isEditing ? this._draftNote?.text || '' : note?.text || '';
+        const displayType = (isEditing ? this._draftNote?.type : note?.type) || 'auto';
+        const timestamp = typeof note?.timestamp === 'number' ? note.timestamp : Date.now();
+
         return html`
-            <div class="transcripts">
-                ${this.transcripts.map(
-                    (item) => html`
-                        <div class="transcript-item">
-                            <div class="transcription">${item.transcription}</div>
-                            <div class="ai-response">${item.ai_response}</div>
-                        </div>
-                    `
-                )}
+            <div class="structured-note">
+                <div class="note-header">
+                    <span class="note-type">${displayType}</span>
+                    <span class="note-timestamp">${this._formatTimestamp(timestamp)}</span>
+                </div>
+                ${isEditing
+                    ? html`
+                          <textarea
+                              class="note-editor"
+                              .value=${displayText}
+                              @input=${this._onDraftTextChange}
+                          ></textarea>
+                          <div class="note-edit-actions">
+                              <select class="note-type-select" .value=${displayType} @change=${this._onDraftTypeChange}>
+                                  <option value="auto">Auto</option>
+                                  <option value="manual">Manual</option>
+                              </select>
+                              <div class="note-actions">
+                                  <button class="note-button primary" @click=${() => this._saveDraft(id)}>Save</button>
+                                  <button class="note-button" @click=${this._cancelEdit}>Cancel</button>
+                              </div>
+                          </div>
+                      `
+                    : html`
+                          <div class="note-text">${displayText}</div>
+                          <div class="note-actions">
+                              <button class="note-button" @click=${() => this._startEdit(note, index)}>Edit</button>
+                              <button class="note-button destructive" @click=${() => this._deleteNote(id)}>Delete</button>
+                          </div>
+                      `}
             </div>
-            <div class="notes">
+        `;
+    }
+
+    render() {
+        const notes = Array.isArray(this.structuredNotes) ? this.structuredNotes : [];
+        return html`
+            <div class="content">
+                <div class="transcript-section">
+                    <div class="section-title">Conversation</div>
+                    ${this.transcripts.length
+                        ? this.transcripts.map(
+                              item => html`
+                                  <div class="transcript-item">
+                                      <div class="transcription">${item.transcription}</div>
+                                      <div class="ai-response">${item.ai_response}</div>
+                                  </div>
+                              `
+                          )
+                        : html`<div class="empty-state">No conversation turns yet</div>`}
+                </div>
+                <div class="structured-notes-section">
+                    <div class="section-title">Structured Notes</div>
+                    <div class="structured-notes-list">
+                        ${notes.length
+                            ? notes.map((note, index) => this._renderStructuredNote(note, index))
+                            : html`<div class="empty-state">No structured notes yet</div>`}
+                    </div>
+                </div>
+            </div>
+            <div class="manual-notes">
+                <div class="section-title">Manual Notes</div>
                 <textarea
-                    .value=${this.notes}
-                    @input=${this._onNotesChange}
-                    placeholder="Notes..."
+                    .value=${this.manualNotes}
+                    @input=${this._onManualNotesChange}
+                    placeholder="Jot down anything you'd like to remember..."
                 ></textarea>
                 <div class="notes-actions">
                     <select class="format-select" .value=${this.exportFormat} @change=${this._onFormatChange}>
                         <option value="json">JSON</option>
                         <option value="markdown">Markdown</option>
                     </select>
-                    <button class="save-button" @click=${this._onSaveSession}>Save session</button>
+                    <button class="save-button" @click=${this._onSaveSession}>Export session</button>
                 </div>
             </div>
         `;

--- a/src/components/views/HistoryView.js
+++ b/src/components/views/HistoryView.js
@@ -135,6 +135,34 @@ export class HistoryView extends LitElement {
             white-space: pre-wrap;
         }
 
+        .session-structured-notes {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .session-structured-note {
+            border: 1px solid var(--button-border);
+            border-radius: 6px;
+            padding: 10px;
+            background: var(--input-background);
+        }
+
+        .session-structured-note-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 6px;
+            font-size: 11px;
+            color: var(--description-color);
+        }
+
+        .session-structured-note-type {
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-weight: 600;
+        }
+
         .back-header {
             display: flex;
             justify-content: space-between;
@@ -439,7 +467,18 @@ export class HistoryView extends LitElement {
             this.loading = true;
             const res = await fetch(`${API_BASE}/history/${sessionId}`);
             const data = await res.json();
-            this.selectedSession = { ...data, notes: data.notes || '' };
+            const structuredNotes = Array.isArray(data.notes) ? data.notes : [];
+            const manualNotes =
+                typeof data.manualNotes === 'string'
+                    ? data.manualNotes
+                    : typeof data.notes === 'string'
+                    ? data.notes
+                    : '';
+            this.selectedSession = {
+                ...data,
+                notes: structuredNotes,
+                manualNotes,
+            };
         } catch (error) {
             logger.error('Error loading session transcript:', error);
         } finally {
@@ -470,7 +509,8 @@ export class HistoryView extends LitElement {
                     sessionId: this.selectedSession.id,
                     history: this.selectedSession.conversationHistory || [],
                 },
-                notes: this.selectedSession.notes || '',
+                structuredNotes: this.selectedSession.notes || [],
+                manualNotes: this.selectedSession.manualNotes || '',
                 profile: this.selectedSession.profile || localStorage.getItem('selectedProfile') || '',
             });
             if (res?.success) {
@@ -595,7 +635,7 @@ export class HistoryView extends LitElement {
     renderConversationView() {
         if (!this.selectedSession) return html``;
 
-        const { conversationHistory, notes } = this.selectedSession;
+        const { conversationHistory, notes, manualNotes } = this.selectedSession;
 
         // Flatten the conversation turns into individual messages
         const messages = [];
@@ -653,11 +693,31 @@ export class HistoryView extends LitElement {
                 </div>
             </div>
             <div class="conversation-view">
-                ${notes
+                ${Array.isArray(notes) && notes.length
                     ? html`
                           <div class="session-notes">
-                              <div class="session-notes-title">Notes</div>
-                              <div class="session-notes-content">${notes}</div>
+                              <div class="session-notes-title">Structured Notes</div>
+                              <div class="session-structured-notes">
+                                  ${notes.map(
+                                      note => html`
+                                          <div class="session-structured-note">
+                                              <div class="session-structured-note-header">
+                                                  <span class="session-structured-note-type">${(note.type || 'auto').toUpperCase()}</span>
+                                                  <span>${this.formatTimestamp(note.timestamp)}</span>
+                                              </div>
+                                              <div class="session-notes-content">${note.text || ''}</div>
+                                          </div>
+                                      `
+                                  )}
+                              </div>
+                          </div>
+                      `
+                    : ''}
+                ${manualNotes
+                    ? html`
+                          <div class="session-notes">
+                              <div class="session-notes-title">Manual Notes</div>
+                              <div class="session-notes-content">${manualNotes}</div>
                           </div>
                       `
                     : ''}

--- a/src/utils/__tests__/historyStore.notes.test.js
+++ b/src/utils/__tests__/historyStore.notes.test.js
@@ -20,25 +20,37 @@ test('Starting a session with sessionStart: true', () => {
     const session = historyStore.getSession(sessionId);
     assert.ok(session);
     assert.deepStrictEqual(session.conversationHistory, []);
+    assert.deepStrictEqual(session.notes, []);
+    assert.strictEqual(session.manualNotes, '');
 });
 
-test('Updating notes independently', () => {
+test('Updating structured notes independently', () => {
     const sessionId = 'notes-update';
     historyStore.appendTurn(sessionId, { sessionStart: true });
-    historyStore.appendTurn(sessionId, { notes: 'First note' });
+    historyStore.appendTurn(sessionId, {
+        notes: [
+            { text: 'Auto summary', type: 'auto', timestamp: 123 },
+            { text: 'Manual insight', type: 'manual', timestamp: 456 },
+        ],
+    });
     let session = historyStore.getSession(sessionId);
-    assert.strictEqual(session.notes, 'First note');
-    historyStore.appendTurn(sessionId, { notes: 'Updated note' });
+    assert.strictEqual(session.notes.length, 2);
+    assert.strictEqual(session.notes[0].text, 'Auto summary');
+    assert.strictEqual(session.manualNotes, '');
+    historyStore.appendTurn(sessionId, { notes: [] });
     session = historyStore.getSession(sessionId);
-    assert.strictEqual(session.notes, 'Updated note');
+    assert.deepStrictEqual(session.notes, []);
     assert.strictEqual(session.conversationHistory.length, 0);
 });
 
-test('getSession returns the latest notes', () => {
-    const sessionId = 'latest-notes';
+test('Legacy string notes update manual notes field', () => {
+    const sessionId = 'legacy-notes';
     historyStore.appendTurn(sessionId, { sessionStart: true });
     historyStore.appendTurn(sessionId, { notes: 'Old note' });
-    historyStore.appendTurn(sessionId, { notes: 'New note' });
-    const session = historyStore.getSession(sessionId);
-    assert.strictEqual(session.notes, 'New note');
+    let session = historyStore.getSession(sessionId);
+    assert.strictEqual(session.manualNotes, 'Old note');
+    assert.deepStrictEqual(session.notes, []);
+    historyStore.appendTurn(sessionId, { manualNotes: 'New note' });
+    session = historyStore.getSession(sessionId);
+    assert.strictEqual(session.manualNotes, 'New note');
 });

--- a/src/utils/__tests__/sessionManager.test.js
+++ b/src/utils/__tests__/sessionManager.test.js
@@ -28,13 +28,19 @@ test('exportSession generates JSON blob with metadata', async () => {
                 },
             ],
         },
-        notes: 'some notes',
+        structuredNotes: [
+            { text: 'auto note', type: 'auto', timestamp: 1 },
+            { text: 'manual note', type: 'manual', timestamp: 2 },
+        ],
+        manualNotes: 'some manual notes',
         profile: 'interview',
     });
     assert.strictEqual(filename, 'session-abc.json');
     const text = await blob.text();
     const data = JSON.parse(text);
-    assert.strictEqual(data.notes, 'some notes');
+    assert.strictEqual(data.notes.length, 2);
+    assert.strictEqual(data.notes[0].text, 'auto note');
+    assert.strictEqual(data.manualNotes, 'some manual notes');
     assert.strictEqual(data.metadata.profile, 'interview');
     assert.strictEqual(data.conversation.length, 1);
 });
@@ -52,11 +58,13 @@ test('exportSession generates Markdown blob', async () => {
                 },
             ],
         },
-        notes: 'note',
+        structuredNotes: [{ text: 'structured', type: 'auto', timestamp: 0 }],
+        manualNotes: 'manual note',
         profile: 'interview',
     });
     const text = await blob.text();
     assert.ok(text.includes('# Session abc'));
-    assert.ok(text.includes('note'));
+    assert.ok(text.includes('structured'));
+    assert.ok(text.includes('manual note'));
     assert.ok(text.includes('hello'));
 });

--- a/src/utils/sessionManager.js
+++ b/src/utils/sessionManager.js
@@ -195,7 +195,14 @@ async function sendImage(geminiSessionRef, data) {
  * @param {Object} [opts.session] - Optional session data { sessionId, history }.
  * @returns {{ blob: Blob, filename: string }}
  */
-function exportSession({ format = 'json', notes = '', profile = '', session } = {}) {
+function exportSession({
+    format = 'json',
+    structuredNotes,
+    notes,
+    manualNotes,
+    profile = '',
+    session,
+} = {}) {
     const exportedAt = new Date().toISOString();
 
     let sessionId;
@@ -219,10 +226,32 @@ function exportSession({ format = 'json', notes = '', profile = '', session } = 
     let mimeType = 'application/json';
     let extension = 'json';
 
+    const noteEntries = Array.isArray(structuredNotes)
+        ? structuredNotes
+        : Array.isArray(notes)
+        ? notes
+        : [];
+    const manualNoteText =
+        typeof manualNotes === 'string'
+            ? manualNotes
+            : typeof notes === 'string'
+            ? notes
+            : '';
+
     if (format === 'markdown' || format === 'md') {
         const lines = [`# Session ${sessionId}`, '', `- Profile: ${profile}`, `- Exported: ${exportedAt}`, ''];
-        if (notes) {
-            lines.push('## Notes', notes, '');
+        if (noteEntries.length) {
+            lines.push('## Structured Notes');
+            noteEntries.forEach(note => {
+                const ts = new Date(
+                    typeof note.timestamp === 'number' ? note.timestamp : Date.now()
+                ).toISOString();
+                lines.push(`- [${(note.type || 'auto').toUpperCase()} | ${ts}] ${note.text || ''}`);
+            });
+            lines.push('');
+        }
+        if (manualNoteText) {
+            lines.push('## Manual Notes', manualNoteText, '');
         }
         lines.push('## Conversation');
         history.forEach(turn => {
@@ -239,7 +268,12 @@ function exportSession({ format = 'json', notes = '', profile = '', session } = 
         mimeType = 'text/markdown';
         extension = 'md';
     } else {
-        const data = { metadata, notes, conversation: history };
+        const data = {
+            metadata,
+            notes: noteEntries,
+            manualNotes: manualNoteText,
+            conversation: history,
+        };
         content = JSON.stringify(data, null, 2);
     }
 

--- a/src/utils/summarizer.js
+++ b/src/utils/summarizer.js
@@ -3,10 +3,12 @@ export function generateNotesFromResponse(resp) {
     const text = typeof resp === 'string' ? resp : resp?.text || '';
     const trimmed = text.trim();
     if (!trimmed) return null;
+    const now = Date.now();
     return {
-      id: Date.now().toString(36),
+      id: now.toString(36),
       text: trimmed,
-      timestamp: Date.now(),
+      timestamp: now,
+      type: 'auto',
     };
   } catch (e) {
     return null;


### PR DESCRIPTION
## Summary
- promote the generated notes array to the primary source of truth and sync it with history persistence
- redesign the assistant side panel to edit structured note entries and keep manual notes separate while updating exports
- update backend storage, history view rendering, and automated tests to support structured notes plus manual notes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7e695289c8331b27283435e6a4000