### PR TITLE
Add transcript timestamps and enhance session export metadata

### DIFF
--- a/backend/historyStore.js
+++ b/backend/historyStore.js
@@ -36,23 +36,31 @@ function saveHistory(history) {
 function appendTurn(sessionId, data) {
     const history = loadHistory();
     let session = history.sessions[sessionId];
+    const eventTimestamp = typeof data.timestamp === 'number' ? data.timestamp : Date.now();
+
     if (!session) {
         session = {
             id: sessionId,
-            timestamp: data.timestamp || Date.now(),
+            timestamp: eventTimestamp,
             conversationHistory: [],
             notes: data.notes || '',
         };
         history.sessions[sessionId] = session;
     }
 
+    session.timestamp = eventTimestamp;
+
     if (typeof data.notes === 'string') {
         session.notes = data.notes;
     }
 
+    if (data.clearTranscripts) {
+        session.conversationHistory = [];
+    }
+
     if (!data.sessionStart && (data.transcription || data.ai_response)) {
         session.conversationHistory.push({
-            timestamp: data.timestamp || Date.now(),
+            timestamp: eventTimestamp,
             transcription: data.transcription || '',
             ai_response: data.ai_response || '',
         });

--- a/src/components/app/SalesWizardApp.js
+++ b/src/components/app/SalesWizardApp.js
@@ -180,6 +180,7 @@ export class SalesWizardApp extends LitElement {
         this.notes = [];
         this.noteText = '';
         this.audioLevel = 0;
+        this._saveConversationTurnHandler = null;
 
         // Apply layout mode to document root
         this.updateLayoutMode();
@@ -199,9 +200,23 @@ export class SalesWizardApp extends LitElement {
             this._clickThroughHandler = (_, isEnabled) => {
                 this._isClickThrough = isEnabled;
             };
+            this._saveConversationTurnHandler = (_, payload) => {
+                if (!payload) {
+                    return;
+                }
+
+                const { fullHistory, turn } = payload;
+                if (Array.isArray(fullHistory)) {
+                    this.transcripts = fullHistory.map(item => ({ ...item }));
+                } else if (turn && typeof turn === 'object') {
+                    this.transcripts = [...this.transcripts, { ...turn }];
+                }
+                this.requestUpdate();
+            };
             window.electron.onUpdateResponse?.(this._updateResponseHandler);
             window.electron.onUpdateStatus?.(this._updateStatusHandler);
             window.electron.onClickThroughToggled?.(this._clickThroughHandler);
+            window.electron.onSaveConversationTurn?.(this._saveConversationTurnHandler);
         }
 
         // Start the voice assistant to listen for spoken questions and
@@ -295,6 +310,7 @@ export class SalesWizardApp extends LitElement {
             window.electron.removeUpdateResponseListener?.(this._updateResponseHandler);
             window.electron.removeUpdateStatusListener?.(this._updateStatusHandler);
             window.electron.removeClickThroughToggledListener?.(this._clickThroughHandler);
+            window.electron.removeSaveConversationTurnListener?.(this._saveConversationTurnHandler);
         }
     }
 

--- a/src/components/app/SalesWizardApp.js
+++ b/src/components/app/SalesWizardApp.js
@@ -224,9 +224,10 @@ export class SalesWizardApp extends LitElement {
                 if (data.reply) {
                     this.setResponse(data.reply);
                     if (this.sessionId) {
+                        const timestamp = Date.now();
                         this.transcripts = [
                             ...this.transcripts,
-                            { transcription: transcript, ai_response: data.reply },
+                            { transcription: transcript, ai_response: data.reply, timestamp },
                         ];
                         try {
                             await fetch(`${API_BASE}/history/${this.sessionId}/turn`, {
@@ -236,6 +237,7 @@ export class SalesWizardApp extends LitElement {
                                     transcription: transcript,
                                     ai_response: data.reply,
                                     notes: this.noteText,
+                                    timestamp,
                                 }),
                             });
                         } catch (err) {
@@ -428,10 +430,11 @@ export class SalesWizardApp extends LitElement {
         this.notes = [];
         this.noteText = '';
         try {
+            const timestamp = Date.now();
             await fetch(`${API_BASE}/history/${this.sessionId}/turn`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ sessionStart: true, notes: '' }),
+                body: JSON.stringify({ sessionStart: true, notes: '', timestamp }),
             });
         } catch (error) {
             logger.error('Failed to start session history:', error);
@@ -498,13 +501,92 @@ export class SalesWizardApp extends LitElement {
         this.noteText = newNotes;
         if (!this.sessionId) return;
         try {
+            const timestamp = Date.now();
             await fetch(`${API_BASE}/history/${this.sessionId}/turn`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ notes: this.noteText }),
+                body: JSON.stringify({ notes: this.noteText, timestamp }),
             });
         } catch (error) {
             logger.error('Failed to save notes:', error);
+        }
+    }
+
+    async handleCopyTranscript() {
+        if (!this.transcripts?.length) {
+            this.setStatus('No transcript available to copy');
+            return;
+        }
+
+        const segments = this.transcripts
+            .map(turn => {
+                const timestamp = turn.timestamp ? new Date(turn.timestamp) : null;
+                const label = timestamp ? timestamp.toLocaleString() : 'Unknown time';
+                const parts = [];
+                if (turn.transcription) {
+                    parts.push(`User [${label}]: ${turn.transcription}`);
+                }
+                if (turn.ai_response) {
+                    parts.push(`Assistant [${label}]: ${turn.ai_response}`);
+                }
+                return parts.join('\n');
+            })
+            .filter(Boolean);
+
+        if (!segments.length) {
+            this.setStatus('No transcript available to copy');
+            return;
+        }
+
+        const transcriptText = segments.join('\n\n');
+
+        try {
+            if (navigator?.clipboard?.writeText) {
+                await navigator.clipboard.writeText(transcriptText);
+            } else if (typeof document !== 'undefined') {
+                const textarea = document.createElement('textarea');
+                textarea.value = transcriptText;
+                textarea.setAttribute('readonly', '');
+                textarea.style.position = 'absolute';
+                textarea.style.left = '-9999px';
+                document.body.appendChild(textarea);
+                textarea.select();
+                document.execCommand('copy');
+                document.body.removeChild(textarea);
+            } else {
+                throw new Error('Clipboard API unavailable');
+            }
+            this.setStatus('Transcript copied to clipboard');
+        } catch (error) {
+            logger.error('Failed to copy transcript:', error);
+            this.setStatus('Failed to copy transcript');
+        }
+    }
+
+    async handleClearSessionData() {
+        this.transcripts = [];
+        this.noteText = '';
+        this.requestUpdate();
+
+        if (!this.sessionId) {
+            return;
+        }
+
+        try {
+            const timestamp = Date.now();
+            await fetch(`${API_BASE}/history/${this.sessionId}/turn`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    notes: '',
+                    clearTranscripts: true,
+                    timestamp,
+                }),
+            });
+            this.setStatus('Session notes and transcript cleared');
+        } catch (error) {
+            logger.error('Failed to clear session data:', error);
+            this.setStatus('Failed to clear session data');
         }
     }
 
@@ -623,6 +705,8 @@ export class SalesWizardApp extends LitElement {
                             .transcripts=${this.transcripts}
                             .selectedProfile=${this.selectedProfile}
                             @notes-change=${e => this.handleNotesChange(e)}
+                            @copy-transcript=${() => this.handleCopyTranscript()}
+                            @clear-session-data=${() => this.handleClearSessionData()}
                         ></side-panel>
                     </div>
                 `;

--- a/src/components/app/SidePanel.js
+++ b/src/components/app/SidePanel.js
@@ -1,4 +1,7 @@
 import { html, css, LitElement } from '../../assets/lit-core-2.7.4.min.js';
+import defaultLogger from '../../utils/logger.js';
+
+const logger = globalThis.logger || defaultLogger || console;
 
 export class SidePanel extends LitElement {
     static styles = css`
@@ -34,12 +37,52 @@ export class SidePanel extends LitElement {
             padding: var(--main-content-padding);
             background: var(--panel-surface-background, rgba(255, 255, 255, 0.02));
             backdrop-filter: inherit;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
         }
 
-        .transcript-item:not(:last-child) {
-            margin-bottom: 16px;
+        .transcripts-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        .transcripts-title {
+            font-size: 16px;
+            font-weight: 600;
+        }
+
+        .transcripts-actions {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+        }
+
+        .transcript-list {
+            flex: 1;
+            overflow-y: auto;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .transcript-item {
             padding-bottom: 12px;
             border-bottom: 1px solid var(--glass-border, var(--border-color));
+        }
+
+        .transcript-item:last-child {
+            border-bottom: none;
+            padding-bottom: 0;
+        }
+
+        .timestamp {
+            font-size: 12px;
+            color: var(--muted-text-color, rgba(255, 255, 255, 0.6));
+            margin-bottom: 6px;
         }
 
         .transcription,
@@ -47,6 +90,11 @@ export class SidePanel extends LitElement {
             margin: 0 0 4px 0;
             font-size: 14px;
             line-height: 1.4;
+        }
+
+        .empty-transcript {
+            font-size: 14px;
+            color: var(--muted-text-color, rgba(255, 255, 255, 0.6));
         }
 
         .notes {
@@ -64,6 +112,7 @@ export class SidePanel extends LitElement {
             gap: 8px;
         }
 
+        .action-button,
         .save-button {
             background: var(--button-background);
             color: var(--text-color);
@@ -76,8 +125,14 @@ export class SidePanel extends LitElement {
             -webkit-backdrop-filter: var(--glass-backdrop-filter, blur(22px) saturate(150%));
         }
 
+        .action-button:hover,
         .save-button:hover {
             background: var(--hover-background);
+        }
+
+        .action-button.danger {
+            color: var(--destructive-text-color, #ff6b6b);
+            border-color: var(--destructive-border-color, rgba(255, 107, 107, 0.6));
         }
 
         .format-select {
@@ -134,6 +189,19 @@ export class SidePanel extends LitElement {
         this.exportFormat = 'json';
     }
 
+    formatTimestamp(timestamp) {
+        if (!timestamp) return 'Unknown time';
+        const date = new Date(timestamp);
+        if (Number.isNaN(date.getTime())) return 'Unknown time';
+        return date.toLocaleString(undefined, {
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            month: 'short',
+            day: 'numeric',
+        });
+    }
+
     _onNotesChange(e) {
         this.notes = e.target.value;
         this.dispatchEvent(
@@ -172,17 +240,59 @@ export class SidePanel extends LitElement {
         }
     }
 
+    _onCopyTranscript() {
+        this.dispatchEvent(
+            new CustomEvent('copy-transcript', {
+                bubbles: true,
+                composed: true,
+            })
+        );
+    }
+
+    _onClearSessionData() {
+        this.dispatchEvent(
+            new CustomEvent('clear-session-data', {
+                bubbles: true,
+                composed: true,
+            })
+        );
+    }
+
     render() {
         return html`
             <div class="transcripts">
-                ${this.transcripts.map(
-                    (item) => html`
-                        <div class="transcript-item">
-                            <div class="transcription">${item.transcription}</div>
-                            <div class="ai-response">${item.ai_response}</div>
-                        </div>
-                    `
-                )}
+                <div class="transcripts-header">
+                    <div class="transcripts-title">Transcript</div>
+                    <div class="transcripts-actions">
+                        <button class="action-button" type="button" @click=${() => this._onCopyTranscript()}>
+                            Copy transcript
+                        </button>
+                        <button
+                            class="action-button danger"
+                            type="button"
+                            @click=${() => this._onClearSessionData()}
+                        >
+                            Clear notes & transcript
+                        </button>
+                    </div>
+                </div>
+                <div class="transcript-list">
+                    ${this.transcripts.length
+                        ? this.transcripts.map(
+                              item => html`
+                                  <div class="transcript-item">
+                                      <div class="timestamp">${this.formatTimestamp(item.timestamp)}</div>
+                                      ${item.transcription
+                                          ? html`<div class="transcription">${item.transcription}</div>`
+                                          : null}
+                                      ${item.ai_response
+                                          ? html`<div class="ai-response">${item.ai_response}</div>`
+                                          : null}
+                                  </div>
+                              `
+                          )
+                        : html`<div class="empty-transcript">No transcript captured yet.</div>`}
+                </div>
             </div>
             <div class="notes">
                 <textarea

--- a/src/utils/__tests__/historyStore.notes.test.js
+++ b/src/utils/__tests__/historyStore.notes.test.js
@@ -42,3 +42,17 @@ test('getSession returns the latest notes', () => {
     const session = historyStore.getSession(sessionId);
     assert.strictEqual(session.notes, 'New note');
 });
+
+test('clearTranscripts removes existing conversation history', () => {
+    const sessionId = 'clear-transcripts';
+    historyStore.appendTurn(sessionId, { sessionStart: true });
+    historyStore.appendTurn(sessionId, { transcription: 'Hi', ai_response: 'Hello', timestamp: 1 });
+    historyStore.appendTurn(sessionId, { transcription: 'How are you?', ai_response: 'Great!', timestamp: 2 });
+    let session = historyStore.getSession(sessionId);
+    assert.strictEqual(session.conversationHistory.length, 2);
+
+    historyStore.appendTurn(sessionId, { clearTranscripts: true, notes: '', timestamp: 3 });
+    session = historyStore.getSession(sessionId);
+    assert.strictEqual(session.conversationHistory.length, 0);
+    assert.strictEqual(session.timestamp, 3);
+});

--- a/src/utils/__tests__/sessionManager.test.js
+++ b/src/utils/__tests__/sessionManager.test.js
@@ -26,6 +26,11 @@ test('exportSession generates JSON blob with metadata', async () => {
                     transcription: 'hello',
                     ai_response: 'hi',
                 },
+                {
+                    timestamp: 60000,
+                    transcription: 'bye',
+                    ai_response: 'see ya',
+                },
             ],
         },
         notes: 'some notes',
@@ -36,7 +41,11 @@ test('exportSession generates JSON blob with metadata', async () => {
     const data = JSON.parse(text);
     assert.strictEqual(data.notes, 'some notes');
     assert.strictEqual(data.metadata.profile, 'interview');
-    assert.strictEqual(data.conversation.length, 1);
+    assert.strictEqual(data.conversation.length, 2);
+    assert.strictEqual(data.metadata.turnCount, 2);
+    assert.strictEqual(data.metadata.startedAt, new Date(0).toISOString());
+    assert.strictEqual(data.metadata.endedAt, new Date(60000).toISOString());
+    assert.ok(data.metadata.exportedAt);
 });
 
 test('exportSession generates Markdown blob', async () => {
@@ -59,4 +68,5 @@ test('exportSession generates Markdown blob', async () => {
     assert.ok(text.includes('# Session abc'));
     assert.ok(text.includes('note'));
     assert.ok(text.includes('hello'));
+    assert.ok(text.includes('Turns: 1'));
 });

--- a/src/utils/sessionManager.js
+++ b/src/utils/sessionManager.js
@@ -209,10 +209,20 @@ function exportSession({ format = 'json', notes = '', profile = '', session } = 
         history = current.history;
     }
 
+    const turnCount = Array.isArray(history) ? history.length : 0;
+    const timestampValues = (history || [])
+        .map(turn => (typeof turn.timestamp === 'number' ? turn.timestamp : null))
+        .filter(value => Number.isFinite(value));
+    const startedAt = timestampValues.length ? new Date(Math.min(...timestampValues)).toISOString() : null;
+    const endedAt = timestampValues.length ? new Date(Math.max(...timestampValues)).toISOString() : null;
+
     const metadata = {
         sessionId,
         exportedAt,
         profile,
+        turnCount,
+        startedAt,
+        endedAt,
     };
 
     let content = '';
@@ -220,13 +230,24 @@ function exportSession({ format = 'json', notes = '', profile = '', session } = 
     let extension = 'json';
 
     if (format === 'markdown' || format === 'md') {
-        const lines = [`# Session ${sessionId}`, '', `- Profile: ${profile}`, `- Exported: ${exportedAt}`, ''];
+        const lines = [`# Session ${sessionId}`, '', `- Profile: ${profile || 'Unknown'}`, `- Exported: ${exportedAt}`];
+        if (metadata.startedAt) {
+            lines.push(`- Started: ${metadata.startedAt}`);
+        }
+        if (metadata.endedAt) {
+            lines.push(`- Ended: ${metadata.endedAt}`);
+        }
+        lines.push(`- Turns: ${turnCount}`);
+        lines.push('');
         if (notes) {
             lines.push('## Notes', notes, '');
         }
         lines.push('## Conversation');
         history.forEach(turn => {
-            const ts = new Date(turn.timestamp).toISOString();
+            const ts =
+                typeof turn.timestamp === 'number'
+                    ? new Date(turn.timestamp).toISOString()
+                    : 'Unknown time';
             if (turn.transcription) {
                 lines.push(`**User (${ts})**: ${turn.transcription}`);
             }


### PR DESCRIPTION
## Summary
- capture and surface transcript timestamps along with copy and clear controls in the side panel
- update history persistence to support clearing transcripts and keep session timestamps current
- extend session export metadata/markdown output and update unit tests for the new fields

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7e69675b08331af101cf54474713f