### PR TITLE
Update content protection handling and remove panic hide shortcut

### DIFF
--- a/src/components/views/AdvancedView.js
+++ b/src/components/views/AdvancedView.js
@@ -344,8 +344,8 @@ export class AdvancedView extends LitElement {
         this.maxTokensPerMin = 1000000;
         this.throttleAtPercent = 75;
 
-        // Content protection default
-        this.contentProtection = true;
+        // Content protection default (disabled until user opts in)
+        this.contentProtection = false;
 
         // History limit default
         this.historyLimit = 50;
@@ -474,15 +474,38 @@ export class AdvancedView extends LitElement {
     }
 
     // Content protection methods
-    loadContentProtectionSetting() {
-        const contentProtection = localStorage.getItem('contentProtection');
-        this.contentProtection = contentProtection !== null ? contentProtection === 'true' : true;
+    async loadContentProtectionSetting() {
+        let enabled = false;
+
+        if (window.electron?.getContentProtection) {
+            try {
+                enabled = await window.electron.getContentProtection();
+            } catch (error) {
+                logger.error('Failed to load content protection:', error);
+            }
+        }
+
+        const legacySetting = localStorage.getItem('contentProtection');
+        if (legacySetting !== null) {
+            const legacyEnabled = legacySetting === 'true';
+            if (legacyEnabled && !enabled && window.electron?.updateContentProtection) {
+                try {
+                    await window.electron.updateContentProtection(true);
+                    enabled = true;
+                } catch (error) {
+                    logger.error('Failed to migrate legacy content protection setting:', error);
+                }
+            }
+            localStorage.removeItem('contentProtection');
+        }
+
+        this.contentProtection = Boolean(enabled);
+        this.requestUpdate();
     }
 
     async handleContentProtectionChange(e) {
         this.contentProtection = e.target.checked;
-        localStorage.setItem('contentProtection', this.contentProtection.toString());
-        
+
         // Update the window's content protection in real-time
         if (window.electron?.updateContentProtection) {
             try {
@@ -491,7 +514,7 @@ export class AdvancedView extends LitElement {
                 logger.error('Failed to update content protection:', error);
             }
         }
-        
+
         this.requestUpdate();
     }
 
@@ -535,8 +558,9 @@ export class AdvancedView extends LitElement {
                         <span>🔒 Content Protection</span>
                     </div>
                     <div class="advanced-description">
-                        Content protection makes the application window invisible to screen sharing and recording software. 
+                        Content protection makes the application window invisible to screen sharing and recording software.
                         This is useful for privacy when sharing your screen, but may interfere with certain display setups like DisplayLink.
+                        The feature stays off unless you explicitly enable it.
                     </div>
 
                     <div class="form-grid">
@@ -549,7 +573,7 @@ export class AdvancedView extends LitElement {
                                 @change=${this.handleContentProtectionChange}
                             />
                             <label for="content-protection" class="checkbox-label">
-                                Enable content protection (stealth mode)
+                                Hide window from screen sharing tools
                             </label>
                         </div>
                         <div class="form-description" style="margin-left: 22px;">

--- a/src/components/views/CustomizeView.js
+++ b/src/components/views/CustomizeView.js
@@ -632,7 +632,6 @@ export class CustomizeView extends LitElement {
             toggleVisibility: isMac ? 'Cmd+\\' : 'Ctrl+\\',
             toggleClickThrough: isMac ? 'Cmd+M' : 'Ctrl+M',
             nextStep: isMac ? 'Cmd+Enter' : 'Ctrl+Enter',
-            panicHide: isMac ? 'Cmd+Esc' : 'Ctrl+Esc',
             toggleMic: isMac ? 'Cmd+Shift+M' : 'Ctrl+Shift+M',
             previousResponse: isMac ? 'Cmd+[' : 'Ctrl+[',
             nextResponse: isMac ? 'Cmd+]' : 'Ctrl+]',
@@ -646,6 +645,9 @@ export class CustomizeView extends LitElement {
         if (savedKeybinds) {
             try {
                 this.keybinds = { ...this.getDefaultKeybinds(), ...JSON.parse(savedKeybinds) };
+                if (this.keybinds.panicHide) {
+                    delete this.keybinds.panicHide;
+                }
             } catch (e) {
                 logger.error('Failed to parse saved keybinds:', e);
                 this.keybinds = this.getDefaultKeybinds();
@@ -707,11 +709,6 @@ export class CustomizeView extends LitElement {
                 key: 'toggleClickThrough',
                 name: 'Toggle Click-through Mode',
                 description: 'Enable/disable click-through functionality',
-            },
-            {
-                key: 'panicHide',
-                name: 'Panic Hide',
-                description: 'Hide overlay and stop capture',
             },
             {
                 key: 'toggleMic',

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,7 @@ require('dotenv').config();
 if (require('electron-squirrel-startup')) {
     process.exit(0);
 }
-require('dotenv').config();
-require("./utils/logger");
+require('./utils/logger');
 
 const { app, BrowserWindow, shell, ipcMain, screen } = require('electron');
 const { createWindow, updateGlobalShortcuts } = require('./utils/window');
@@ -11,6 +10,9 @@ const { setupGeminiIpcHandlers, stopMacOSAudioCapture, sendToRenderer } = requir
 const { registerSecureStoreIpc } = require('./utils/secureStore');
 const { initializeRandomProcessNames } = require('./utils/processRandomizer');
 const { applyAntiAnalysisMeasures } = require('./utils/stealthFeatures');
+const settingsStore = require('./utils/settingsStore');
+
+const STEALTH = process.env.STEALTH === '1';
 
 const geminiSessionRef = { current: null };
 let mainWindow = null;
@@ -20,17 +22,22 @@ let contextParams = {
     disallowedTopics: '',
 };
 
-// Initialize random process names for stealth
-const randomNames = initializeRandomProcessNames();
+// Initialize random process names for stealth when enabled
+const randomNames = STEALTH ? initializeRandomProcessNames() : null;
 
 function createMainWindow() {
-    mainWindow = createWindow(sendToRenderer, geminiSessionRef, randomNames);
+    const contentProtectionEnabled = settingsStore.getSetting('contentProtection', false);
+    mainWindow = createWindow(sendToRenderer, geminiSessionRef, randomNames, {
+        contentProtectionEnabled,
+    });
     return mainWindow;
 }
 
 app.whenReady().then(async () => {
-    // Apply anti-analysis measures with random delay
-    await applyAntiAnalysisMeasures();
+    if (STEALTH) {
+        // Apply anti-analysis measures with random delay
+        await applyAntiAnalysisMeasures();
+    }
 
     createMainWindow();
     setupGeminiIpcHandlers(geminiSessionRef);
@@ -83,11 +90,15 @@ function setupGeneralIpcHandlers() {
         }
     });
 
-    ipcMain.handle('update-content-protection', async () => {
+    ipcMain.handle('update-content-protection', async (_event, enabled) => {
         try {
+            let contentProtection = settingsStore.getSetting('contentProtection', false);
+            if (typeof enabled === 'boolean') {
+                contentProtection = enabled;
+                settingsStore.setSetting('contentProtection', contentProtection);
+            }
+
             if (mainWindow) {
-                // Get content protection setting from localStorage via Sales Wizard
-                const contentProtection = await mainWindow.webContents.executeJavaScript('salesWizard.getContentProtection()');
                 mainWindow.setContentProtection(contentProtection);
                 logger.info('Content protection updated:', contentProtection);
             }
@@ -95,6 +106,15 @@ function setupGeneralIpcHandlers() {
         } catch (error) {
             logger.error('Error updating content protection:', error);
             return { success: false, error: error.message };
+        }
+    });
+
+    ipcMain.handle('get-content-protection', async () => {
+        try {
+            return settingsStore.getSetting('contentProtection', false);
+        } catch (error) {
+            logger.error('Error retrieving content protection state:', error);
+            return false;
         }
     });
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -23,6 +23,7 @@ const api = {
     ipcRenderer.invoke('update-google-search-setting', enabled),
   updateContentProtection: enabled =>
     ipcRenderer.invoke('update-content-protection', enabled),
+  getContentProtection: () => ipcRenderer.invoke('get-content-protection'),
   getRandomDisplayName: () => ipcRenderer.invoke('get-random-display-name'),
   exportSession: options => ipcRenderer.invoke('export-session', options),
   onUpdateResponse: handler => ipcRenderer.on('update-response', handler),

--- a/src/utils/renderer.js
+++ b/src/utils/renderer.js
@@ -1004,9 +1004,17 @@ const salesWizard = {
     initConversationStorage,
 
     // Content protection function
-    getContentProtection: () => {
-        const contentProtection = localStorage.getItem('contentProtection');
-        return contentProtection !== null ? contentProtection === 'true' : true;
+    getContentProtection: async () => {
+        try {
+            if (window.electron?.getContentProtection) {
+                return await window.electron.getContentProtection();
+            }
+        } catch (error) {
+            logger.error('Failed to read content protection preference:', error);
+        }
+
+        const legacySetting = localStorage.getItem('contentProtection');
+        return legacySetting === 'true';
     },
 
     // Platform detection

--- a/src/utils/settingsStore.js
+++ b/src/utils/settingsStore.js
@@ -1,0 +1,69 @@
+const { app } = require('electron');
+const fs = require('node:fs');
+const path = require('node:path');
+
+let settingsCache = null;
+
+function getSettingsFilePath() {
+    const userDataPath = app.getPath('userData');
+    return path.join(userDataPath, 'settings.json');
+}
+
+function loadSettings() {
+    if (settingsCache) {
+        return settingsCache;
+    }
+
+    const filePath = getSettingsFilePath();
+
+    try {
+        if (fs.existsSync(filePath)) {
+            const raw = fs.readFileSync(filePath, 'utf8');
+            settingsCache = JSON.parse(raw);
+            return settingsCache;
+        }
+    } catch (error) {
+        (globalThis.logger || console).warn('Failed to load settings, using defaults:', error);
+    }
+
+    settingsCache = {};
+    return settingsCache;
+}
+
+function saveSettings() {
+    const filePath = getSettingsFilePath();
+    const directory = path.dirname(filePath);
+
+    try {
+        fs.mkdirSync(directory, { recursive: true });
+        fs.writeFileSync(filePath, JSON.stringify(settingsCache ?? {}, null, 2), 'utf8');
+    } catch (error) {
+        (globalThis.logger || console).error('Failed to persist settings:', error);
+    }
+}
+
+function getSetting(key, defaultValue = undefined) {
+    const settings = loadSettings();
+    if (Object.prototype.hasOwnProperty.call(settings, key)) {
+        return settings[key];
+    }
+    return defaultValue;
+}
+
+function setSetting(key, value) {
+    const settings = loadSettings();
+
+    if (value === undefined) {
+        delete settings[key];
+    } else {
+        settings[key] = value;
+    }
+
+    saveSettings();
+    return settings[key];
+}
+
+module.exports = {
+    getSetting,
+    setSetting,
+};

--- a/src/utils/window.js
+++ b/src/utils/window.js
@@ -46,7 +46,7 @@ function ensureDataDirectories() {
     return { imageDir, audioDir };
 }
 
-function createWindow(sendToRenderer, geminiSessionRef, randomNames = null) {
+function createWindow(sendToRenderer, geminiSessionRef, randomNames = null, options = {}) {
     // Get layout preference (default to 'normal')
     let windowWidth = 840;
     let windowHeight = 460;
@@ -122,7 +122,8 @@ function createWindow(sendToRenderer, geminiSessionRef, randomNames = null) {
             // ignore: best effort only
         }
     }
-    mainWindow.setContentProtection(true);
+    const { contentProtectionEnabled = false } = options;
+    mainWindow.setContentProtection(Boolean(contentProtectionEnabled));
     mainWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
 
     mainWindow.once('ready-to-show', () => {
@@ -161,7 +162,7 @@ function createWindow(sendToRenderer, geminiSessionRef, randomNames = null) {
                     `
                 try {
                     const savedKeybinds = localStorage.getItem('customKeybinds');
-                    
+
                     return {
                         keybinds: savedKeybinds ? JSON.parse(savedKeybinds) : null
                     };
@@ -170,26 +171,14 @@ function createWindow(sendToRenderer, geminiSessionRef, randomNames = null) {
                 }
             `
                 )
-                .then(async savedSettings => {
+                .then(savedSettings => {
                     if (savedSettings.keybinds) {
                         keybinds = { ...defaultKeybinds, ...savedSettings.keybinds };
-                    }
-
-                    // Apply content protection setting via IPC handler
-                    try {
-                        const contentProtection = await mainWindow.webContents.executeJavaScript('salesWizard.getContentProtection()');
-                        mainWindow.setContentProtection(contentProtection);
-                        logger.info('Content protection loaded from settings:', contentProtection);
-                    } catch (error) {
-                        logger.error('Error loading content protection:', error);
-                        mainWindow.setContentProtection(true);
                     }
 
                     updateGlobalShortcuts(keybinds, mainWindow, sendToRenderer, geminiSessionRef);
                 })
                 .catch(() => {
-                    // Default to content protection enabled
-                    mainWindow.setContentProtection(true);
                     updateGlobalShortcuts(keybinds, mainWindow, sendToRenderer, geminiSessionRef);
                 });
         }, 150);
@@ -210,7 +199,6 @@ function getDefaultKeybinds() {
         toggleVisibility: isMac ? 'Cmd+\\' : 'Ctrl+\\',
         toggleClickThrough: isMac ? 'Cmd+M' : 'Ctrl+M',
         nextStep: isMac ? 'Cmd+Enter' : 'Ctrl+Enter',
-        panicHide: isMac ? 'Cmd+Esc' : 'Ctrl+Esc',
         toggleMic: isMac ? 'Cmd+Shift+M' : 'Ctrl+Shift+M',
         previousResponse: isMac ? 'Cmd+[' : 'Ctrl+[',
         nextResponse: isMac ? 'Cmd+]' : 'Ctrl+]',
@@ -299,23 +287,6 @@ function updateGlobalShortcuts(keybinds, mainWindow, sendToRenderer) {
             logger.info(`Registered toggleClickThrough: ${keybinds.toggleClickThrough}`);
         } catch (error) {
             logger.error(`Failed to register toggleClickThrough (${keybinds.toggleClickThrough}):`, error);
-        }
-    }
-
-    // Panic hide shortcut
-    if (keybinds.panicHide) {
-        try {
-            globalShortcut.register(keybinds.panicHide, () => {
-                try {
-                    if (mainWindow.isVisible()) mainWindow.hide();
-                    mainWindow.webContents.executeJavaScript('salesWizard && salesWizard.stopCapture && salesWizard.stopCapture()').catch(() => {});
-                } catch (err) {
-                    logger.error('Error during panicHide:', err);
-                }
-            });
-            logger.info(`Registered panicHide: ${keybinds.panicHide}`);
-        } catch (error) {
-            logger.error(`Failed to register panicHide (${keybinds.panicHide}):`, error);
         }
     }
 


### PR DESCRIPTION
## Summary
- gate stealth randomization logic behind the STEALTH environment flag and persist content protection settings with a dedicated store
- replace renderer executeJavaScript calls with IPC-backed content protection toggling that defaults to disabled and refresh the settings UI copy
- remove the unused panic hide keybinding from both the default shortcuts and customization UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7e696f9508331a10489dc19243d46