### PR TITLE
Enforce backend auth token and CORS restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ The repository includes a Flutter demonstration of a "liquid glass" task manager
 ## Setup
 
 1. **Get a Gemini API Key**: Visit [Google AI Studio](https://aistudio.google.com/apikey)
-2. **Copy the Example Environment File**: `cp .env.example .env` and add your `GEMINI_API_KEY`
+2. **Copy the Example Environment File**: `cp .env.example .env` and add your `GEMINI_API_KEY`. Set `AUTH_TOKEN`
+   to a secret string and optionally configure `ALLOWED_ORIGINS` with a comma-separated list of frontend origins
+   allowed to call the backend. Requests to `/ask`, `/history/*`, and `/live` must include the correct token via an
+   `AUTH_TOKEN` header or query parameter.
 3. **Install Dependencies**: `npm install`
 4. **Run the App**: `npm start` (starts backend and desktop client)
 
@@ -95,8 +98,8 @@ requirements and configuration for this feature.
 | Variable         | Description                                                                                  |
 | ---------------- | -------------------------------------------------------------------------------------------- |
 | `APP_NAME`       | Human-readable name exposed by helper processes. Defaults to `Sales Wizard`.                |
-| `AUTH_TOKEN`     | Secret token required by the backend to authorize live streaming connections.               |
-| `ALLOWED_ORIGINS`| Comma-separated list of origins permitted to open live WebSocket connections.               |
+| `AUTH_TOKEN`     | Secret token required by the backend to authorize `/ask`, `/history/*`, and `/live` access. Provide it via the `AUTH_TOKEN` header or query string. |
+| `ALLOWED_ORIGINS`| Comma-separated list of origins permitted to call backend HTTP and WebSocket endpoints. Leave blank to allow any origin. |
 
 #### IPC Channels
 
@@ -118,6 +121,15 @@ npm run start:backend
 ```
 
 By default the server listens on port 3001 (or the value of the `PORT` environment variable).
+
+### Backend Security
+
+- **Authorization**: Protected endpoints (`/ask`, `/history/*`, and the `/live` WebSocket) reject requests that do not
+  include the configured `AUTH_TOKEN`. Supply the token using an `AUTH_TOKEN` header (recommended) or as an
+  `authToken`/`AUTH_TOKEN` query parameter.
+- **CORS**: Incoming requests must originate from an entry listed in `ALLOWED_ORIGINS`. If the variable is empty, the
+  backend accepts calls from any origin; otherwise, disallowed origins are rejected with `403` before reaching your
+  handlers.
 
 ## API Endpoints
 

--- a/backend/__tests__/auth.test.js
+++ b/backend/__tests__/auth.test.js
@@ -1,0 +1,69 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+process.env.AUTH_TOKEN = 'test-secret-token';
+process.env.ALLOWED_ORIGINS = 'http://allowed.test';
+process.env.PORT = 0;
+
+const { startServer } = require('../server');
+
+async function createServer(t) {
+  const { server, wss } = startServer({ port: 0 });
+  const address = server.address();
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  t.after(async () => {
+    await new Promise(resolve => wss.close(resolve));
+    await new Promise(resolve => server.close(resolve));
+  });
+
+  return { baseUrl };
+}
+
+test('rejects POST /ask without an auth token', async (t) => {
+  const { baseUrl } = await createServer(t);
+  const response = await fetch(`${baseUrl}/ask`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: 'http://allowed.test'
+    },
+    body: JSON.stringify({ prompt: 'hello' })
+  });
+
+  assert.strictEqual(response.status, 401);
+  const payload = await response.json();
+  assert.strictEqual(payload.error, 'Unauthorized');
+});
+
+test('rejects history requests with an invalid token', async (t) => {
+  const { baseUrl } = await createServer(t);
+  const response = await fetch(`${baseUrl}/history`, {
+    method: 'GET',
+    headers: {
+      AUTH_TOKEN: 'wrong-token',
+      Origin: 'http://allowed.test'
+    }
+  });
+
+  assert.strictEqual(response.status, 401);
+  const payload = await response.json();
+  assert.strictEqual(payload.error, 'Unauthorized');
+});
+
+test('rejects requests from disallowed origins before auth', async (t) => {
+  const { baseUrl } = await createServer(t);
+  const response = await fetch(`${baseUrl}/ask`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      AUTH_TOKEN: 'test-secret-token',
+      Origin: 'http://blocked.test'
+    },
+    body: JSON.stringify({ prompt: 'hello' })
+  });
+
+  assert.strictEqual(response.status, 403);
+  const payload = await response.json();
+  assert.strictEqual(payload.error, 'Origin not allowed');
+});

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,5 @@
 require('dotenv').config();
-require("../src/utils/logger");
+require('../src/utils/logger');
 const express = require('express');
 const { GoogleGenAI, Modality } = require('@google/genai');
 const { WebSocketServer } = require('ws');
@@ -8,6 +8,69 @@ const historyStore = require('./historyStore');
 const app = express();
 app.use(express.json());
 const genai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || '' });
+
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map(origin => origin.trim())
+  .filter(Boolean);
+
+function isOriginAllowed(origin) {
+  if (!origin || allowedOrigins.length === 0) {
+    return true;
+  }
+  return allowedOrigins.includes(origin);
+}
+
+app.use((req, res, next) => {
+  const origin = req.get('Origin');
+  if (origin && !isOriginAllowed(origin)) {
+    return res.status(403).json({ error: 'Origin not allowed' });
+  }
+
+  if (origin) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+  }
+
+  res.setHeader('Access-Control-Allow-Credentials', 'true');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, AUTH_TOKEN');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
+
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(204);
+  }
+
+  return next();
+});
+
+function getConfiguredToken() {
+  return (process.env.AUTH_TOKEN || '').trim();
+}
+
+function extractAuthToken(req) {
+  const headerToken = (req.get('AUTH_TOKEN') || '').trim();
+  const queryToken = (req.query?.AUTH_TOKEN || req.query?.authToken || '').trim();
+  return headerToken || queryToken;
+}
+
+function authMiddleware(req, res, next) {
+  if (req.method === 'OPTIONS') {
+    return next();
+  }
+
+  const configuredToken = getConfiguredToken();
+  if (!configuredToken) {
+    logger.error('AUTH_TOKEN environment variable is not configured.');
+    return res.status(500).json({ error: 'Server misconfiguration' });
+  }
+
+  const providedToken = extractAuthToken(req);
+  if (providedToken !== configuredToken) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  return next();
+}
 
 // In-memory state for conversation history and context parameters
 const state = {
@@ -39,7 +102,7 @@ app.put('/context-params', (req, res) => {
   res.json({ success: true, data: state.contextParams });
 });
 
-app.post('/ask', async (req, res) => {
+app.post('/ask', authMiddleware, async (req, res) => {
   const prompt = req.body.prompt || '';
   try {
     const model = genai.getGenerativeModel({
@@ -56,7 +119,7 @@ app.post('/ask', async (req, res) => {
   }
 });
 
-app.post('/history/:sessionId/turn', (req, res) => {
+app.post('/history/:sessionId/turn', authMiddleware, (req, res) => {
   const { sessionId } = req.params;
   try {
     historyStore.appendTurn(sessionId, req.body || {});
@@ -68,7 +131,7 @@ app.post('/history/:sessionId/turn', (req, res) => {
 });
 
 // Clear all stored history sessions
-app.delete('/history', (_req, res) => {
+app.delete('/history', authMiddleware, (_req, res) => {
   try {
     historyStore.clearHistory();
     res.json({ ok: true });
@@ -78,7 +141,7 @@ app.delete('/history', (_req, res) => {
   }
 });
 
-app.get('/history', (req, res) => {
+app.get('/history', authMiddleware, (req, res) => {
   try {
     const sessions = historyStore.listSessions();
     res.json(sessions);
@@ -88,7 +151,7 @@ app.get('/history', (req, res) => {
   }
 });
 
-app.get('/history/:sessionId', (req, res) => {
+app.get('/history/:sessionId', authMiddleware, (req, res) => {
   try {
     const session = historyStore.getSession(req.params.sessionId);
     if (!session) {
@@ -102,7 +165,7 @@ app.get('/history/:sessionId', (req, res) => {
 });
 
 // Update maximum stored session count
-app.put('/history/limit', (req, res) => {
+app.put('/history/limit', authMiddleware, (req, res) => {
   try {
     historyStore.setMaxSessions(req.body?.limit);
     res.json({ ok: true, limit: req.body?.limit });
@@ -112,33 +175,80 @@ app.put('/history/limit', (req, res) => {
   }
 });
 
-const server = app.listen(process.env.PORT || 3001);
+function startWebSocketServer(serverInstance) {
+  const wssInstance = new WebSocketServer({ server: serverInstance, path: '/live' });
+  wssInstance.on('connection', async (ws, req) => {
+    const origin = req.headers?.origin;
+    if (origin && !isOriginAllowed(origin)) {
+      ws.close(1008, 'Origin not allowed');
+      return;
+    }
 
-// WebSocket endpoint for Gemini Live
-const wss = new WebSocketServer({ server, path: '/live' });
-wss.on('connection', async (ws) => {
-  const session = await genai.live.connect({
-    model: 'gemini-live-2.5-flash-preview',
-    config: { response_modalities: [Modality.TEXT], system_instruction: buildSystemInstruction() }
+    const configuredToken = getConfiguredToken();
+    if (!configuredToken) {
+      logger.error('AUTH_TOKEN environment variable is not configured.');
+      ws.close(1011, 'Server misconfiguration');
+      return;
+    }
+
+    const headerToken = (req.headers?.auth_token || req.headers?.['auth-token'] || '').trim();
+    const requestUrl = new URL(req.url, 'http://localhost');
+    const queryToken =
+      (requestUrl.searchParams.get('AUTH_TOKEN') || requestUrl.searchParams.get('authToken') || '').trim();
+    const providedToken = headerToken || queryToken;
+
+    if (providedToken !== configuredToken) {
+      ws.close(1008, 'Unauthorized');
+      return;
+    }
+
+    try {
+      const session = await genai.live.connect({
+        model: 'gemini-live-2.5-flash-preview',
+        config: { response_modalities: [Modality.TEXT], system_instruction: buildSystemInstruction() }
+      });
+
+      // Forward Gemini replies back to the client
+      (async () => {
+        for await (const response of session.receive()) {
+          ws.send(JSON.stringify({ text: response.text || '' }));
+        }
+      })();
+
+      ws.on('message', async (msg) => {
+        const data = JSON.parse(msg);
+        if (data.audio) {
+          const buf = Buffer.from(data.audio, 'base64');
+          await session.send_realtime_input({
+            audio: { data: buf, mime_type: data.mimeType || 'audio/pcm;rate=16000' }
+          });
+        } else if (data.image) {
+          const buf = Buffer.from(data.image, 'base64');
+          await session.send_realtime_input({
+            image: { data: buf, mime_type: data.mimeType || 'image/jpeg' }
+          });
+        }
+      });
+
+      ws.on('close', () => session.close());
+    } catch (err) {
+      logger.error('Failed to initialize Gemini Live session:', err);
+      ws.close(1011, 'Gemini Live initialization failed');
+    }
   });
 
-  // Forward Gemini replies back to the client
-  (async () => {
-    for await (const response of session.receive()) {
-      ws.send(JSON.stringify({ text: response.text || '' }));
-    }
-  })();
+  return wssInstance;
+}
 
-  ws.on('message', async (msg) => {
-    const data = JSON.parse(msg);
-    if (data.audio) {
-      const buf = Buffer.from(data.audio, 'base64');
-      await session.send_realtime_input({ audio: { data: buf, mime_type: data.mimeType || 'audio/pcm;rate=16000' } });
-    } else if (data.image) {
-      const buf = Buffer.from(data.image, 'base64');
-      await session.send_realtime_input({ image: { data: buf, mime_type: data.mimeType || 'image/jpeg' } });
-    }
-  });
+function startServer({ port } = {}) {
+  const listenPort = port ?? process.env.PORT ?? 3001;
+  const serverInstance = app.listen(listenPort);
+  const wssInstance = startWebSocketServer(serverInstance);
+  return { server: serverInstance, wss: wssInstance };
+}
 
-  ws.on('close', () => session.close());
-});
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = { app, startServer, state };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "make": "node -r dotenv/config node_modules/.bin/electron-forge make",
     "publish": "node -r dotenv/config node_modules/.bin/electron-forge publish",
     "lint": "eslint .",
-    "test": "node -r ./src/utils/logger.js --test src/utils/__tests__/*.test.js",
+    "test": "node -r ./src/utils/logger.js --test src/utils/__tests__/*.test.js backend/__tests__/*.test.js",
     "format": "prettier --write ."
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- add backend middleware to enforce AUTH_TOKEN checks on /ask, history routes, and the live websocket
- configure CORS using the ALLOWED_ORIGINS environment variable and reuse it in the websocket handshake
- document the new configuration in the README and add node:test coverage for unauthorized requests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7e698bec48331b187a0873c6dce35