### PR TITLE
Add backend and renderer test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,6 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
-      - run: npm test
+      - run: npm run lint
+      - run: npm run test:backend
+      - run: npm run test:renderer

--- a/backend/__tests__/server.jest.test.js
+++ b/backend/__tests__/server.jest.test.js
@@ -1,0 +1,129 @@
+const request = require('supertest');
+const WebSocket = require('ws');
+const { createBackend } = require('../server');
+const { createMockGenai } = require('../../tests/fixtures/mockGenai');
+
+function createHistoryStore() {
+  return {
+    appendTurn: jest.fn(),
+    clearHistory: jest.fn(),
+    listSessions: jest.fn().mockReturnValue([{ id: 'session-1' }]),
+    getSession: jest.fn(id => (id === 'session-1' ? { id, turns: [] } : null)),
+    setMaxSessions: jest.fn(),
+  };
+}
+
+describe('backend/server', () => {
+  let logger;
+
+  beforeEach(() => {
+    logger = { info: jest.fn(), error: jest.fn() };
+  });
+
+  test('updates context params and builds system instruction', async () => {
+    const historyStore = createHistoryStore();
+    const { genai } = createMockGenai();
+    const backend = createBackend({ logger, historyStoreImpl: historyStore, genaiClient: genai });
+    const agent = request(backend.app);
+
+    await agent.put('/context-params').send({ allowedSources: 'Docs', toneLength: 'Short' }).expect(200);
+    const response = await agent.get('/context-params').expect(200);
+    expect(response.body).toEqual({
+      allowedSources: 'Docs',
+      toneLength: 'Short',
+      disallowedTopics: '',
+    });
+
+    const instruction = backend.buildSystemInstruction();
+    expect(instruction).toContain('Docs');
+    expect(instruction).toContain('Short');
+  });
+
+  test('answers ask endpoint and records history', async () => {
+    const historyStore = createHistoryStore();
+    const { genai } = createMockGenai({ replyText: 'Hello there' });
+    const backend = createBackend({ logger, historyStoreImpl: historyStore, genaiClient: genai });
+    const agent = request(backend.app);
+
+    const res = await agent.post('/ask').send({ prompt: 'Hi' }).expect(200);
+    expect(res.body).toEqual({ reply: 'Hello there' });
+    expect(backend.state.history).toEqual([{ prompt: 'Hi', reply: 'Hello there' }]);
+  });
+
+  test('handles generation errors gracefully', async () => {
+    const historyStore = createHistoryStore();
+    const { genai } = createMockGenai();
+    const error = new Error('boom');
+    genai.getGenerativeModel().generateContent.mockRejectedValueOnce(error);
+    const backend = createBackend({ logger, historyStoreImpl: historyStore, genaiClient: genai });
+    const agent = request(backend.app);
+
+    const res = await agent.post('/ask').send({ prompt: 'Hi' }).expect(500);
+    expect(res.body).toEqual({ error: 'Generation failed' });
+    expect(logger.error).toHaveBeenCalledWith('Error:', error);
+  });
+
+  test('delegates to history store implementations', async () => {
+    const historyStore = createHistoryStore();
+    const backend = createBackend({ logger, historyStoreImpl: historyStore, genaiClient: createMockGenai().genai });
+    const agent = request(backend.app);
+
+    await agent.post('/history/test-session/turn').send({ role: 'user' }).expect(200);
+    expect(historyStore.appendTurn).toHaveBeenCalledWith('test-session', { role: 'user' });
+
+    await agent.delete('/history').expect(200);
+    expect(historyStore.clearHistory).toHaveBeenCalled();
+
+    await agent.get('/history').expect(200);
+    expect(historyStore.listSessions).toHaveBeenCalled();
+
+    await agent.put('/history/limit').send({ limit: 10 }).expect(200);
+    expect(historyStore.setMaxSessions).toHaveBeenCalledWith(10);
+
+    const notFound = await agent.get('/history/unknown').expect(404);
+    expect(notFound.body).toEqual({ error: 'Not found' });
+  });
+
+  test('websocket bridge proxies messages to Gemini and back', async () => {
+    const responses = [{ text: 'streamed response' }];
+    const { genai, session } = createMockGenai({ responses });
+    const historyStore = createHistoryStore();
+    const backend = createBackend({
+      logger,
+      historyStoreImpl: historyStore,
+      genaiClient: genai,
+      ModalityEnum: { TEXT: 'TEXT' },
+      port: 0,
+    });
+
+    const server = backend.app.listen(0);
+    const address = server.address();
+    const port = typeof address === 'object' ? address.port : 0;
+    const wss = backend.attachLiveWebSocket(server);
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/live`);
+
+    await new Promise(resolve => ws.on('open', resolve));
+
+    const messagePromise = new Promise(resolve => ws.on('message', data => resolve(data.toString())));
+
+    const payload = { audio: Buffer.from('abc').toString('base64'), mimeType: 'audio/test' };
+    ws.send(JSON.stringify(payload));
+
+    await new Promise(resolve => setImmediate(resolve));
+    expect(session.sentInputs).toHaveLength(1);
+    expect(session.sentInputs[0]).toEqual({
+      audio: { data: Buffer.from('abc'), mime_type: 'audio/test' },
+    });
+
+    const message = await messagePromise;
+    expect(JSON.parse(message)).toEqual({ text: 'streamed response' });
+
+    ws.close();
+    await new Promise(resolve => ws.on('close', resolve));
+    expect(session.closed).toBe(true);
+
+    await new Promise(resolve => wss.close(resolve));
+    await new Promise(resolve => server.close(resolve));
+  });
+});

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,144 +1,185 @@
 require('dotenv').config();
-require("../src/utils/logger");
+require('../src/utils/logger');
 const express = require('express');
 const { GoogleGenAI, Modality } = require('@google/genai');
 const { WebSocketServer } = require('ws');
 const historyStore = require('./historyStore');
 
-const app = express();
-app.use(express.json());
-const genai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || '' });
+function createBackend(options = {}) {
+  const {
+    logger = globalThis.logger || console,
+    historyStoreImpl = historyStore,
+    genaiClient,
+    port = process.env.PORT || 3001,
+    ModalityEnum = Modality,
+  } = options;
 
-// In-memory state for conversation history and context parameters
-const state = {
-  history: [],
-  contextParams: {
-    allowedSources: '',
-    toneLength: '',
-    disallowedTopics: '',
-  },
-};
+  const app = express();
+  app.use(express.json());
 
-// Helper to build system instructions from stored parameters
-function buildSystemInstruction() {
-  const parts = ['You are a helpful assistant.'];
-  const { allowedSources, toneLength, disallowedTopics } = state.contextParams;
-  if (allowedSources) parts.push(`Limit knowledge retrieval to: ${allowedSources}.`);
-  if (toneLength) parts.push(`Maintain tone/length constraints: ${toneLength}.`);
-  if (disallowedTopics) parts.push(`Avoid the following topics: ${disallowedTopics}.`);
-  return parts.join(' ');
+  const genai = genaiClient || new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || '' });
+
+  // In-memory state for conversation history and context parameters
+  const state = {
+    history: [],
+    contextParams: {
+      allowedSources: '',
+      toneLength: '',
+      disallowedTopics: '',
+    },
+  };
+
+  // Helper to build system instructions from stored parameters
+  function buildSystemInstruction() {
+    const parts = ['You are a helpful assistant.'];
+    const { allowedSources, toneLength, disallowedTopics } = state.contextParams;
+    if (allowedSources) parts.push(`Limit knowledge retrieval to: ${allowedSources}.`);
+    if (toneLength) parts.push(`Maintain tone/length constraints: ${toneLength}.`);
+    if (disallowedTopics) parts.push(`Avoid the following topics: ${disallowedTopics}.`);
+    return parts.join(' ');
+  }
+
+  // Context parameters endpoints
+  app.get('/context-params', (_req, res) => {
+    res.json(state.contextParams);
+  });
+
+  app.put('/context-params', (req, res) => {
+    state.contextParams = { ...state.contextParams, ...req.body };
+    res.json({ success: true, data: state.contextParams });
+  });
+
+  app.post('/ask', async (req, res) => {
+    const prompt = req.body.prompt || '';
+    try {
+      const model = genai.getGenerativeModel({
+        model: 'gemini-pro',
+        systemInstruction: buildSystemInstruction(),
+      });
+      const result = await model.generateContent([{ role: 'user', parts: [{ text: prompt }] }]);
+      const reply = result?.candidates?.[0]?.content?.parts?.[0]?.text?.trim() || '';
+      state.history.push({ prompt, reply });
+      res.json({ reply });
+    } catch (err) {
+      logger.error('Error:', err);
+      res.status(500).json({ error: 'Generation failed' });
+    }
+  });
+
+  app.post('/history/:sessionId/turn', (req, res) => {
+    const { sessionId } = req.params;
+    try {
+      historyStoreImpl.appendTurn(sessionId, req.body || {});
+      res.json({ ok: true });
+    } catch (err) {
+      logger.error('Error saving history turn:', err);
+      res.status(500).json({ error: 'Failed to save turn' });
+    }
+  });
+
+  // Clear all stored history sessions
+  app.delete('/history', (_req, res) => {
+    try {
+      historyStoreImpl.clearHistory();
+      res.json({ ok: true });
+    } catch (err) {
+      logger.error('Error clearing history:', err);
+      res.status(500).json({ error: 'Failed to clear history' });
+    }
+  });
+
+  app.get('/history', (req, res) => {
+    try {
+      const sessions = historyStoreImpl.listSessions();
+      res.json(sessions);
+    } catch (err) {
+      logger.error('Error listing history:', err);
+      res.status(500).json({ error: 'Failed to list history' });
+    }
+  });
+
+  app.get('/history/:sessionId', (req, res) => {
+    try {
+      const session = historyStoreImpl.getSession(req.params.sessionId);
+      if (!session) {
+        return res.status(404).json({ error: 'Not found' });
+      }
+      res.json(session);
+    } catch (err) {
+      logger.error('Error loading session:', err);
+      res.status(500).json({ error: 'Failed to load session' });
+    }
+  });
+
+  // Update maximum stored session count
+  app.put('/history/limit', (req, res) => {
+    try {
+      historyStoreImpl.setMaxSessions(req.body?.limit);
+      res.json({ ok: true, limit: req.body?.limit });
+    } catch (err) {
+      logger.error('Error updating history limit:', err);
+      res.status(500).json({ error: 'Failed to update limit' });
+    }
+  });
+
+  async function handleLiveConnection(ws) {
+    const session = await genai.live.connect({
+      model: 'gemini-live-2.5-flash-preview',
+      config: { response_modalities: [ModalityEnum.TEXT], system_instruction: buildSystemInstruction() },
+    });
+
+    (async () => {
+      for await (const response of session.receive()) {
+        ws.send(JSON.stringify({ text: response.text || '' }));
+      }
+    })().catch(err => logger.error('Error streaming Gemini response:', err));
+
+    ws.on('message', async msg => {
+      try {
+        const data = JSON.parse(msg);
+        if (data.audio) {
+          const buf = Buffer.from(data.audio, 'base64');
+          await session.send_realtime_input({
+            audio: { data: buf, mime_type: data.mimeType || 'audio/pcm;rate=16000' },
+          });
+        } else if (data.image) {
+          const buf = Buffer.from(data.image, 'base64');
+          await session.send_realtime_input({ image: { data: buf, mime_type: data.mimeType || 'image/jpeg' } });
+        }
+      } catch (err) {
+        logger.error('Error handling live message:', err);
+      }
+    });
+
+    ws.on('close', () => {
+      if (typeof session.close === 'function') {
+        session.close();
+      }
+    });
+
+    return session;
+  }
+
+  function attachLiveWebSocket(serverInstance) {
+    const wss = new WebSocketServer({ server: serverInstance, path: '/live' });
+    wss.on('connection', ws => {
+      handleLiveConnection(ws).catch(err => logger.error('Failed to establish live session:', err));
+    });
+    return wss;
+  }
+
+  function start() {
+    const serverInstance = app.listen(port);
+    const wss = attachLiveWebSocket(serverInstance);
+    return { server: serverInstance, wss };
+  }
+
+  return { app, state, buildSystemInstruction, start, attachLiveWebSocket };
 }
 
-// Context parameters endpoints
-app.get('/context-params', (_req, res) => {
-  res.json(state.contextParams);
-});
+if (require.main === module) {
+  const { start } = createBackend();
+  start();
+}
 
-app.put('/context-params', (req, res) => {
-  state.contextParams = { ...state.contextParams, ...req.body };
-  res.json({ success: true, data: state.contextParams });
-});
-
-app.post('/ask', async (req, res) => {
-  const prompt = req.body.prompt || '';
-  try {
-    const model = genai.getGenerativeModel({
-      model: 'gemini-pro',
-      systemInstruction: buildSystemInstruction(),
-    });
-    const result = await model.generateContent([{ role: 'user', parts: [{ text: prompt }] }]);
-    const reply = result?.candidates?.[0]?.content?.parts?.[0]?.text?.trim() || '';
-    state.history.push({ prompt, reply });
-    res.json({ reply });
-  } catch (err) {
-    logger.error('Error:', err);
-    res.status(500).json({ error: 'Generation failed' });
-  }
-});
-
-app.post('/history/:sessionId/turn', (req, res) => {
-  const { sessionId } = req.params;
-  try {
-    historyStore.appendTurn(sessionId, req.body || {});
-    res.json({ ok: true });
-  } catch (err) {
-    logger.error('Error saving history turn:', err);
-    res.status(500).json({ error: 'Failed to save turn' });
-  }
-});
-
-// Clear all stored history sessions
-app.delete('/history', (_req, res) => {
-  try {
-    historyStore.clearHistory();
-    res.json({ ok: true });
-  } catch (err) {
-    logger.error('Error clearing history:', err);
-    res.status(500).json({ error: 'Failed to clear history' });
-  }
-});
-
-app.get('/history', (req, res) => {
-  try {
-    const sessions = historyStore.listSessions();
-    res.json(sessions);
-  } catch (err) {
-    logger.error('Error listing history:', err);
-    res.status(500).json({ error: 'Failed to list history' });
-  }
-});
-
-app.get('/history/:sessionId', (req, res) => {
-  try {
-    const session = historyStore.getSession(req.params.sessionId);
-    if (!session) {
-      return res.status(404).json({ error: 'Not found' });
-    }
-    res.json(session);
-  } catch (err) {
-    logger.error('Error loading session:', err);
-    res.status(500).json({ error: 'Failed to load session' });
-  }
-});
-
-// Update maximum stored session count
-app.put('/history/limit', (req, res) => {
-  try {
-    historyStore.setMaxSessions(req.body?.limit);
-    res.json({ ok: true, limit: req.body?.limit });
-  } catch (err) {
-    logger.error('Error updating history limit:', err);
-    res.status(500).json({ error: 'Failed to update limit' });
-  }
-});
-
-const server = app.listen(process.env.PORT || 3001);
-
-// WebSocket endpoint for Gemini Live
-const wss = new WebSocketServer({ server, path: '/live' });
-wss.on('connection', async (ws) => {
-  const session = await genai.live.connect({
-    model: 'gemini-live-2.5-flash-preview',
-    config: { response_modalities: [Modality.TEXT], system_instruction: buildSystemInstruction() }
-  });
-
-  // Forward Gemini replies back to the client
-  (async () => {
-    for await (const response of session.receive()) {
-      ws.send(JSON.stringify({ text: response.text || '' }));
-    }
-  })();
-
-  ws.on('message', async (msg) => {
-    const data = JSON.parse(msg);
-    if (data.audio) {
-      const buf = Buffer.from(data.audio, 'base64');
-      await session.send_realtime_input({ audio: { data: buf, mime_type: data.mimeType || 'audio/pcm;rate=16000' } });
-    } else if (data.image) {
-      const buf = Buffer.from(data.image, 'base64');
-      await session.send_realtime_input({ image: { data: buf, mime_type: data.mimeType || 'image/jpeg' } });
-    }
-  });
-
-  ws.on('close', () => session.close());
-});
+module.exports = { createBackend };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/*.jest.test.js'],
+  collectCoverage: true,
+  collectCoverageFrom: ['backend/**/*.js', 'src/utils/**/*.js', 'src/preload.js'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/__tests__/'],
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "make": "node -r dotenv/config node_modules/.bin/electron-forge make",
     "publish": "node -r dotenv/config node_modules/.bin/electron-forge publish",
     "lint": "eslint .",
-    "test": "node -r ./src/utils/logger.js --test src/utils/__tests__/*.test.js",
+    "test": "npm run test:backend && npm run test:renderer",
+    "test:backend": "jest --runInBand",
+    "test:renderer": "npm run test:renderer:node && npm run test:renderer:vitest",
+    "test:renderer:node": "node -r ./src/utils/logger.js --test src/utils/__tests__/*.test.js",
+    "test:renderer:vitest": "vitest run",
     "format": "prettier --write ."
   },
   "keywords": [
@@ -51,7 +55,10 @@
     "concurrently": "^8.2.2",
     "electron": "^30.0.5",
     "eslint": "^8.57.1",
+    "jest": "^29.7.0",
     "mock-fs": "^5.5.0",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "supertest": "^7.1.1",
+    "vitest": "^2.1.4"
   }
 }

--- a/src/components/app/__tests__/AppHeader.vitest.test.js
+++ b/src/components/app/__tests__/AppHeader.vitest.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../../utils/config.js', () => ({
+  getAppName: () => 'Test App',
+}));
+
+import '../AppHeader.js';
+
+function getShadowRoot(element) {
+  const root = element.shadowRoot;
+  if (!root) {
+    throw new Error('Shadow root not available');
+  }
+  return root;
+}
+
+describe('AppHeader', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders streaming status indicators for assistant view', async () => {
+    const element = document.createElement('app-header');
+    document.body.appendChild(element);
+
+    element.currentView = 'assistant';
+    element.connectionState = 'connected';
+    element.audioState = 'capturing';
+    element.screenState = 'sharing';
+    element.statusText = 'Live';
+    element.onHideToggleClick = vi.fn();
+    element.onCloseClick = vi.fn();
+
+    await element.updateComplete;
+
+    const root = getShadowRoot(element);
+    const indicators = Array.from(root.querySelectorAll('.status-indicator'));
+    expect(indicators).toHaveLength(3);
+    expect(indicators.map(indicator => indicator.dataset.state)).toEqual([
+      'connected',
+      'capturing',
+      'sharing',
+    ]);
+
+    const hideButton = root.querySelector('.button');
+    hideButton.click();
+    expect(element.onHideToggleClick).toHaveBeenCalled();
+  });
+
+  it('invokes navigation handlers in main view', async () => {
+    const element = document.createElement('app-header');
+    document.body.appendChild(element);
+
+    element.currentView = 'main';
+    element.advancedMode = false;
+    element.onHistoryClick = vi.fn();
+    element.onCustomizeClick = vi.fn();
+    element.onHelpClick = vi.fn();
+    element.onCloseClick = vi.fn();
+
+    await element.updateComplete;
+    const root = getShadowRoot(element);
+
+    const buttons = Array.from(root.querySelectorAll('.icon-button'));
+    buttons[0].click();
+    expect(element.onHistoryClick).toHaveBeenCalled();
+
+    buttons[1].click();
+    expect(element.onCustomizeClick).toHaveBeenCalled();
+
+    buttons[2].click();
+    expect(element.onHelpClick).toHaveBeenCalled();
+  });
+});

--- a/src/components/app/__tests__/AudioLevelIndicator.vitest.test.js
+++ b/src/components/app/__tests__/AudioLevelIndicator.vitest.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import '../AudioLevelIndicator.js';
+
+describe('AudioLevelIndicator', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('clamps the audio level between 0 and 100 percent', async () => {
+    const el = document.createElement('audio-level-indicator');
+    document.body.appendChild(el);
+
+    el.level = 1.2;
+    await el.updateComplete;
+    let level = el.shadowRoot.querySelector('.level');
+    expect(level.style.width).toBe('100%');
+
+    el.level = -0.5;
+    await el.updateComplete;
+    level = el.shadowRoot.querySelector('.level');
+    expect(level.style.width).toBe('0%');
+  });
+
+  it('updates width when level changes', async () => {
+    const el = document.createElement('audio-level-indicator');
+    document.body.appendChild(el);
+
+    el.level = 0.42;
+    await el.updateComplete;
+    const level = el.shadowRoot.querySelector('.level');
+    expect(level.style.width).toBe('42%');
+  });
+});

--- a/src/components/app/__tests__/NoteStreamPanel.vitest.test.js
+++ b/src/components/app/__tests__/NoteStreamPanel.vitest.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import '../NoteStreamPanel.js';
+
+describe('NoteStreamPanel', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders notes pushed through helper methods', async () => {
+    const el = document.createElement('note-stream-panel');
+    document.body.appendChild(el);
+
+    el.addNote('First');
+    el.addNote('Second');
+    await el.updateComplete;
+
+    const notes = Array.from(el.shadowRoot.querySelectorAll('.note-item')).map(item => item.textContent.trim());
+    expect(notes).toEqual(['First', 'Second']);
+
+    el.clear();
+    await el.updateComplete;
+    expect(el.shadowRoot.querySelectorAll('.note-item')).toHaveLength(0);
+  });
+});

--- a/tests/fixtures/mockGenai.js
+++ b/tests/fixtures/mockGenai.js
@@ -1,0 +1,60 @@
+class MockLiveSession {
+  constructor(responses = []) {
+    this._responses = responses;
+    this.sentInputs = [];
+    this.closed = false;
+  }
+
+  async *receive() {
+    for (const response of this._responses) {
+      // Simulate asynchronous delivery
+      await Promise.resolve();
+      yield response;
+    }
+  }
+
+  async send_realtime_input(payload) {
+    this.sentInputs.push(payload);
+    return { ok: true };
+  }
+
+  async close() {
+    this.closed = true;
+  }
+}
+
+function createMockGenai({ responses = [], replyText = 'Mock reply' } = {}) {
+  const session = new MockLiveSession(responses);
+  const generateContent = jest.fn().mockResolvedValue({
+    candidates: [
+      {
+        content: {
+          parts: [
+            {
+              text: replyText,
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  const getGenerativeModel = jest.fn().mockReturnValue({ generateContent });
+
+  const live = {
+    connect: jest.fn().mockResolvedValue(session),
+  };
+
+  return {
+    session,
+    genai: {
+      live,
+      getGenerativeModel,
+    },
+  };
+}
+
+module.exports = {
+  MockLiveSession,
+  createMockGenai,
+};

--- a/tests/ipc/gemini.ipc.jest.test.js
+++ b/tests/ipc/gemini.ipc.jest.test.js
@@ -1,0 +1,140 @@
+jest.mock('electron', () => {
+  const handlers = new Map();
+  return {
+    ipcMain: {
+      handle: jest.fn((channel, handler) => {
+        handlers.set(channel, handler);
+      }),
+      __handlers: handlers,
+    },
+  };
+});
+
+jest.mock('../../src/utils/audioHandler', () => ({
+  stopMacOSAudioCapture: jest.fn(),
+  startMacOSAudioCapture: jest.fn().mockResolvedValue(true),
+  killExistingSystemAudioDump: jest.fn(),
+  convertStereoToMono: jest.fn(),
+  sendAudioToGemini: jest.fn(),
+}));
+
+jest.mock('../../src/utils/reconnection', () => ({
+  clearSessionParams: jest.fn(),
+  sendReconnectionContext: jest.fn(),
+  attemptReconnection: jest.fn(),
+}));
+
+jest.mock('../../src/utils/sessionManager', () => ({
+  initializeGeminiSession: jest.fn(),
+  sendImage: jest.fn(),
+  sendTextMessage: jest.fn(),
+  exportSession: jest.fn(() => ({
+    blob: {
+      type: 'text/plain',
+      async arrayBuffer() {
+        return new TextEncoder().encode('data').buffer;
+      },
+    },
+    filename: 'notes.txt',
+  })),
+  getEnabledTools: jest.fn(),
+  getStoredSetting: jest.fn(),
+}));
+
+jest.mock('../../src/utils/conversationStore', () => ({
+  initializeNewSession: jest.fn(() => 'session-123'),
+  saveConversationTurn: jest.fn(),
+  getCurrentSessionData: jest.fn(() => ({ id: 'session-123' })),
+}));
+
+const { ipcMain } = require('electron');
+const audioHandler = require('../../src/utils/audioHandler');
+const reconnection = require('../../src/utils/reconnection');
+const sessionManager = require('../../src/utils/sessionManager');
+const conversationStore = require('../../src/utils/conversationStore');
+
+const { setupGeminiIpcHandlers } = require('../../src/utils/gemini');
+
+describe('Gemini IPC handlers', () => {
+  let geminiSessionRef;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    ipcMain.__handlers.clear();
+    geminiSessionRef = { current: null };
+    global.logger = { error: jest.fn(), info: jest.fn(), warn: jest.fn() };
+  });
+
+  function getHandler(channel) {
+    expect(ipcMain.__handlers.has(channel)).toBe(true);
+    return ipcMain.__handlers.get(channel);
+  }
+
+  test('initializes gemini session and caches reference', async () => {
+    const fakeSession = { close: jest.fn() };
+    sessionManager.initializeGeminiSession.mockResolvedValue(fakeSession);
+    setupGeminiIpcHandlers(geminiSessionRef);
+
+    const result = await getHandler('initialize-gemini')('key', 'prompt', 'profile', 'en');
+    expect(result).toBe(true);
+    expect(geminiSessionRef.current).toBe(fakeSession);
+  });
+
+  test('send-audio-content requires active session', async () => {
+    setupGeminiIpcHandlers(geminiSessionRef);
+    const result = await getHandler('send-audio-content')({ data: Buffer.from('a'), mimeType: 'audio' });
+    expect(result).toEqual({ success: false, error: 'No active Gemini session' });
+  });
+
+  test('start-macos-audio guards non-mac platforms', async () => {
+    setupGeminiIpcHandlers(geminiSessionRef);
+    const handler = getHandler('start-macos-audio');
+    const response = await handler();
+    expect(response).toEqual({
+      success: false,
+      error: 'macOS audio capture only available on macOS',
+    });
+  });
+
+  test('start-macos-audio delegates when running on macOS', async () => {
+    setupGeminiIpcHandlers(geminiSessionRef);
+    const handler = getHandler('start-macos-audio');
+    const platformSpy = jest.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+
+    const result = await handler();
+    expect(result).toEqual({ success: true });
+    expect(audioHandler.startMacOSAudioCapture).toHaveBeenCalled();
+
+    platformSpy.mockRestore();
+  });
+
+  test('close-session stops audio, clears reconnection and closes session', async () => {
+    const close = jest.fn();
+    geminiSessionRef.current = { close };
+    setupGeminiIpcHandlers(geminiSessionRef);
+
+    const result = await getHandler('close-session')();
+    expect(result).toEqual({ success: true });
+    expect(audioHandler.stopMacOSAudioCapture).toHaveBeenCalled();
+    expect(reconnection.clearSessionParams).toHaveBeenCalled();
+    expect(close).toHaveBeenCalled();
+    expect(geminiSessionRef.current).toBeNull();
+  });
+
+  test('export-session returns serialized blob data', async () => {
+    setupGeminiIpcHandlers(geminiSessionRef);
+    const handler = getHandler('export-session');
+    const result = await handler({});
+    expect(result.success).toBe(true);
+    expect(result.filename).toBe('notes.txt');
+    expect(typeof result.data).toBe('string');
+  });
+
+  test('start-new-session returns new session id', async () => {
+    setupGeminiIpcHandlers(geminiSessionRef);
+    const handler = getHandler('start-new-session');
+    const result = await handler();
+    expect(result).toEqual({ success: true, sessionId: 'session-123' });
+    expect(conversationStore.initializeNewSession).toHaveBeenCalled();
+  });
+});

--- a/tests/ipc/preload.jest.test.js
+++ b/tests/ipc/preload.jest.test.js
@@ -1,0 +1,54 @@
+jest.mock('electron', () => {
+  const invoke = jest.fn();
+  const send = jest.fn();
+  const on = jest.fn();
+  const removeListener = jest.fn();
+  const removeAllListeners = jest.fn();
+
+  return {
+    contextBridge: {
+      exposeInMainWorld: jest.fn(),
+    },
+    ipcRenderer: {
+      invoke,
+      send,
+      on,
+      removeListener,
+      removeAllListeners,
+    },
+  };
+});
+
+const { contextBridge, ipcRenderer } = require('electron');
+
+describe('preload IPC bridge', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('exposes renderer api on window', () => {
+    require('../../src/preload');
+    expect(contextBridge.exposeInMainWorld).toHaveBeenCalledWith('electron', expect.any(Object));
+  });
+
+  test('renderer api delegates to ipcRenderer', () => {
+    require('../../src/preload');
+    const api = contextBridge.exposeInMainWorld.mock.calls[0][1];
+
+    api.updateSizes();
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith('update-sizes');
+
+    api.viewChanged('assistant');
+    expect(ipcRenderer.send).toHaveBeenCalledWith('view-changed', 'assistant');
+
+    const handler = jest.fn();
+    api.onUpdateResponse(handler);
+    expect(ipcRenderer.on).toHaveBeenCalledWith('update-response', handler);
+
+    api.removeUpdateResponseListener(handler);
+    expect(ipcRenderer.removeListener).toHaveBeenCalledWith('update-response', handler);
+
+    api.removeSessionInitializingListeners();
+    expect(ipcRenderer.removeAllListeners).toHaveBeenCalledWith('session-initializing');
+  });
+});

--- a/tests/setup/vitest.setup.js
+++ b/tests/setup/vitest.setup.js
@@ -1,0 +1,6 @@
+// Provide a predictable salesWizard runtime flag for components that check platform details.
+if (!globalThis.window) {
+  globalThis.window = globalThis;
+}
+
+globalThis.window.salesWizard = { isMacOS: false };

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,13 @@
+const { defineConfig } = require('vitest/config');
+const path = require('path');
+
+module.exports = defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['**/*.vitest.test.js'],
+    setupFiles: [path.resolve(__dirname, 'tests/setup/vitest.setup.js')],
+    coverage: {
+      reporter: ['text', 'lcov'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- refactor the backend server into a testable factory that exposes injectable dependencies and websocket setup helpers
- add Jest suites that cover HTTP endpoints, websocket forwarding, preload exposure, and Gemini IPC handlers with reusable Gemini/WebSocket fixtures
- configure Vitest for Lit components, seed component smoke tests, and expand CI and npm scripts to lint plus run backend and renderer suites

## Testing
- npm run test:backend *(fails in this environment: jest executable not available)*
- npm run test:renderer *(fails in this environment: vitest executable not available)*
- npm run test:renderer:node

------
https://chatgpt.com/codex/tasks/task_e_68e7e697e10c8331a1c0ad4ff41315c1