### PR TITLE
feat: route renderer history calls via IPC

### DIFF
--- a/src/components/app/SalesWizardApp.js
+++ b/src/components/app/SalesWizardApp.js
@@ -15,11 +15,9 @@ import { startListening } from '../../utils/voiceAssistant.js';
 // Live streaming helper integrates with Gemini Live via backend
 import { startLiveStreaming } from '../../utils/liveStreamer.js';
 import defaultLogger from '../../utils/logger.js';
-import { resolveBackendOrigin } from '../../services/backendConfig.js';
 
 // Use global logger if available, falling back to the imported logger or console
 const logger = globalThis.logger || defaultLogger || console;
-const API_BASE = resolveBackendOrigin();
 
 export class SalesWizardApp extends LitElement {
     static styles = css`
@@ -215,36 +213,38 @@ export class SalesWizardApp extends LitElement {
         // so it can be cleaned up in disconnectedCallback().
         this._stopVoiceAssistant = startListening(async transcript => {
             try {
-                const res = await fetch(`${API_BASE}/ask`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ prompt: transcript }),
-                });
-                const data = await res.json();
-                if (data.reply) {
-                    this.setResponse(data.reply);
-                    if (this.sessionId) {
-                        this.transcripts = [
-                            ...this.transcripts,
-                            { transcription: transcript, ai_response: data.reply },
-                        ];
-                        try {
-                            await fetch(`${API_BASE}/history/${this.sessionId}/turn`, {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({
-                                    transcription: transcript,
-                                    ai_response: data.reply,
-                                    notes: this.noteText,
-                                }),
-                            });
-                        } catch (err) {
-                            logger.error('Failed to post turn:', err);
-                        }
+                if (!window.electron?.assistantAsk) {
+                    throw new Error('assistantAsk IPC bridge unavailable');
+                }
+
+                const result = await window.electron.assistantAsk(transcript);
+                if (!result?.success) {
+                    throw new Error(result?.error || 'Assistant request failed');
+                }
+
+                const reply = result?.data?.reply?.trim?.() || '';
+                if (!reply) {
+                    return;
+                }
+
+                this.setResponse(reply);
+                if (this.sessionId) {
+                    this.transcripts = [
+                        ...this.transcripts,
+                        { transcription: transcript, ai_response: reply },
+                    ];
+                    try {
+                        await this.persistHistoryTurn({
+                            transcription: transcript,
+                            ai_response: reply,
+                            notes: this.noteText,
+                        });
+                    } catch (err) {
+                        logger.error('Failed to post turn:', err);
                     }
                 }
             } catch (err) {
-                logger.error('Voice assistant fetch failed:', err);
+                logger.error('Voice assistant request failed:', err);
             }
         });
 
@@ -428,11 +428,7 @@ export class SalesWizardApp extends LitElement {
         this.notes = [];
         this.noteText = '';
         try {
-            await fetch(`${API_BASE}/history/${this.sessionId}/turn`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ sessionStart: true, notes: '' }),
-            });
+            await this.persistHistoryTurn({ sessionStart: true, notes: '' });
         } catch (error) {
             logger.error('Failed to start session history:', error);
         }
@@ -498,13 +494,25 @@ export class SalesWizardApp extends LitElement {
         this.noteText = newNotes;
         if (!this.sessionId) return;
         try {
-            await fetch(`${API_BASE}/history/${this.sessionId}/turn`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ notes: this.noteText }),
-            });
+            await this.persistHistoryTurn({ notes: this.noteText });
         } catch (error) {
             logger.error('Failed to save notes:', error);
+        }
+    }
+
+    async persistHistoryTurn(turn) {
+        if (!this.sessionId) return;
+        if (!window.electron?.historyAddTurn) {
+            throw new Error('historyAddTurn IPC bridge unavailable');
+        }
+
+        const result = await window.electron.historyAddTurn({
+            sessionId: this.sessionId,
+            turn,
+        });
+
+        if (!result?.success) {
+            throw new Error(result?.error || 'Failed to persist history turn');
         }
     }
 

--- a/src/components/views/CustomizeView.js
+++ b/src/components/views/CustomizeView.js
@@ -573,7 +573,7 @@ export class CustomizeView extends LitElement {
 
     updateContextParams() {
         try {
-            window.electron?.setContextParams?.({
+            window.electron?.contextSet?.({
                 allowedSources: this.allowedSources,
                 toneLength: this.toneLength,
                 disallowedTopics: this.disallowedTopics,

--- a/src/components/views/HistoryView.js
+++ b/src/components/views/HistoryView.js
@@ -1,8 +1,5 @@
 import { html, css, LitElement } from '../../assets/lit-core-2.7.4.min.js';
 import { resizeLayout } from '../../utils/windowResize.js';
-import { resolveBackendOrigin } from '../../services/backendConfig.js';
-
-const API_BASE = resolveBackendOrigin();
 
 export class HistoryView extends LitElement {
     static styles = css`
@@ -381,20 +378,24 @@ export class HistoryView extends LitElement {
         // Resize window for this view
         resizeLayout();
         const limit = localStorage.getItem('historySessionLimit');
-        if (limit) {
-            fetch(`${API_BASE}/history/limit`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ limit }),
-            }).catch(err => logger.error('Failed to apply history limit:', err));
+        if (limit && window.electron?.historySetLimit) {
+            window.electron.historySetLimit(limit).catch(err => logger.error('Failed to apply history limit:', err));
         }
     }
 
     async loadSessions() {
         try {
-        this.loading = true;
-        const response = await fetch(`${API_BASE}/history`);
-        this.sessions = await response.json();
+            this.loading = true;
+            if (window.electron?.historyList) {
+                const result = await window.electron.historyList();
+                if (result?.success) {
+                    this.sessions = Array.isArray(result.data) ? result.data : [];
+                } else {
+                    throw new Error(result?.error || 'Failed to load history');
+                }
+            } else {
+                this.sessions = [];
+            }
         } catch (error) {
             logger.error('Error loading conversation sessions:', error);
             this.sessions = [];
@@ -437,9 +438,15 @@ export class HistoryView extends LitElement {
     async fetchSession(sessionId) {
         try {
             this.loading = true;
-            const res = await fetch(`${API_BASE}/history/${sessionId}`);
-            const data = await res.json();
-            this.selectedSession = { ...data, notes: data.notes || '' };
+            if (window.electron?.historyGet) {
+                const result = await window.electron.historyGet(sessionId);
+                if (result?.success) {
+                    const data = result.data || {};
+                    this.selectedSession = { ...data, notes: data.notes || '' };
+                } else {
+                    throw new Error(result?.error || 'Failed to load session');
+                }
+            }
         } catch (error) {
             logger.error('Error loading session transcript:', error);
         } finally {
@@ -453,9 +460,15 @@ export class HistoryView extends LitElement {
 
     async handleClearHistory() {
         try {
-            await fetch(`${API_BASE}/history`, { method: 'DELETE' });
-            this.sessions = [];
-            this.selectedSession = null;
+            if (window.electron?.historyClear) {
+                const result = await window.electron.historyClear();
+                if (result?.success) {
+                    this.sessions = [];
+                    this.selectedSession = null;
+                } else {
+                    throw new Error(result?.error || 'Failed to clear history');
+                }
+            }
         } catch (error) {
             logger.error('Error clearing history:', error);
         }

--- a/src/components/views/SidePanel.js
+++ b/src/components/views/SidePanel.js
@@ -1,0 +1,1 @@
+export * from '../app/SidePanel.js';

--- a/src/index.js
+++ b/src/index.js
@@ -107,12 +107,12 @@ function setupGeneralIpcHandlers() {
         }
     });
 
-    ipcMain.handle('set-context-params', async (_event, params) => {
+    ipcMain.handle('context:set', async (_event, params) => {
         contextParams = { ...contextParams, ...params };
-        return { success: true };
+        return { success: true, data: contextParams };
     });
 
-    ipcMain.handle('get-context-params', async () => {
+    ipcMain.handle('context:get', async () => {
         return { success: true, data: contextParams };
     });
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -18,13 +18,20 @@ const api = {
   openExternal: url => ipcRenderer.invoke('open-external', url),
   viewChanged: view => ipcRenderer.send('view-changed', view),
   updateKeybinds: keybinds => ipcRenderer.send('update-keybinds', keybinds),
-  setContextParams: params => ipcRenderer.invoke('set-context-params', params),
+  contextGet: () => ipcRenderer.invoke('context:get'),
+  contextSet: params => ipcRenderer.invoke('context:set', params),
   updateGoogleSearchSetting: enabled =>
     ipcRenderer.invoke('update-google-search-setting', enabled),
   updateContentProtection: enabled =>
     ipcRenderer.invoke('update-content-protection', enabled),
   getRandomDisplayName: () => ipcRenderer.invoke('get-random-display-name'),
   exportSession: options => ipcRenderer.invoke('export-session', options),
+  historyList: () => ipcRenderer.invoke('history:list'),
+  historyGet: sessionId => ipcRenderer.invoke('history:get', sessionId),
+  historyClear: () => ipcRenderer.invoke('history:clear'),
+  historySetLimit: limit => ipcRenderer.invoke('history:set-limit', limit),
+  historyAddTurn: payload => ipcRenderer.invoke('history:add-turn', payload),
+  assistantAsk: prompt => ipcRenderer.invoke('assistant:ask', prompt),
   onUpdateResponse: handler => ipcRenderer.on('update-response', handler),
   removeUpdateResponseListener: handler =>
     ipcRenderer.removeListener('update-response', handler),

--- a/src/utils/__tests__/renderer.history-view.test.js
+++ b/src/utils/__tests__/renderer.history-view.test.js
@@ -1,0 +1,47 @@
+const { test, mock } = require('node:test');
+const assert = require('node:assert');
+const { setupRendererGlobals } = require('./rendererTestUtils.js');
+
+test('HistoryView loads sessions and selects a session via IPC', async () => {
+  const { cleanup } = setupRendererGlobals();
+
+  const historyList = mock.fn(async () => ({
+    success: true,
+    data: [
+      { id: 'session-1', timestamp: 1700000000000, preview: 'First conversation' },
+    ],
+  }));
+
+  const historyGet = mock.fn(async () => ({
+    success: true,
+    data: {
+      id: 'session-1',
+      notes: 'Important notes',
+      conversationHistory: [
+        { transcription: 'Question?', ai_response: 'Answer.' },
+      ],
+    },
+  }));
+
+  window.electron.historyList = historyList;
+  window.electron.historyGet = historyGet;
+
+  const module = await import('../../components/views/HistoryView.js');
+  const HistoryView = module.HistoryView || customElements.get('history-view');
+
+  const element = new HistoryView();
+  await element.loadSessions();
+
+  assert.ok(historyList.mock.callCount() >= 1, 'historyList IPC invoked');
+  assert.strictEqual(element.sessions.length, 1, 'one session returned');
+  assert.strictEqual(element.loading, false, 'loading flag reset after list');
+
+  await element.fetchSession('session-1');
+
+  assert.strictEqual(historyGet.mock.callCount(), 1, 'historyGet IPC called once');
+  assert.ok(element.selectedSession, 'session is selected');
+  assert.strictEqual(element.selectedSession.id, 'session-1');
+  assert.strictEqual(element.selectedSession.notes, 'Important notes');
+
+  cleanup();
+});

--- a/src/utils/__tests__/renderer.sales-wizard-app.test.js
+++ b/src/utils/__tests__/renderer.sales-wizard-app.test.js
@@ -1,0 +1,60 @@
+const { test, mock } = require('node:test');
+const assert = require('node:assert');
+const { setupRendererGlobals } = require('./rendererTestUtils.js');
+
+test('handleStart uses IPC bridge to persist session and switches view', async () => {
+  const { cleanup, localStorage } = setupRendererGlobals();
+
+  localStorage.setItem('onboardingCompleted', '1');
+  localStorage.setItem('apiKey', 'secret');
+
+  const historyAddTurn = mock.fn(async () => ({ success: true }));
+  window.electron.historyAddTurn = historyAddTurn;
+  window.electron.assistantAsk = mock.fn(async () => ({ success: true, data: { reply: 'ok' } }));
+
+  window.salesWizard.initializeGemini = mock.fn(async () => ({}));
+  window.salesWizard.startCapture = mock.fn();
+  window.salesWizard.sendTextMessage = mock.fn(async () => ({ success: true }));
+
+  const module = await import('../../components/app/SalesWizardApp.js');
+  const SalesWizardApp = module.SalesWizardApp || customElements.get('sales-wizard-app');
+
+  const element = new SalesWizardApp();
+  await element.handleStart();
+
+  assert.strictEqual(window.salesWizard.initializeGemini.mock.callCount(), 1);
+  assert.strictEqual(window.salesWizard.startCapture.mock.callCount(), 1);
+  assert.strictEqual(historyAddTurn.mock.callCount(), 1);
+  assert.strictEqual(element.currentView, 'assistant');
+
+  cleanup();
+});
+
+test('handleNotesChange saves notes through IPC bridge', async () => {
+  const { cleanup, localStorage } = setupRendererGlobals();
+
+  localStorage.setItem('onboardingCompleted', '1');
+  localStorage.setItem('apiKey', 'secret');
+
+  const historyAddTurn = mock.fn(async () => ({ success: true }));
+  window.electron.historyAddTurn = historyAddTurn;
+
+  window.salesWizard.initializeGemini = mock.fn(async () => ({}));
+  window.salesWizard.startCapture = mock.fn();
+
+  const module = await import('../../components/app/SalesWizardApp.js');
+  const SalesWizardApp = module.SalesWizardApp || customElements.get('sales-wizard-app');
+
+  const element = new SalesWizardApp();
+  element.sessionId = 'session-123';
+
+  await element.handleNotesChange({ detail: { value: 'Updated notes' } });
+
+  assert.strictEqual(historyAddTurn.mock.callCount(), 1);
+  assert.deepStrictEqual(historyAddTurn.mock.calls[0].arguments[0], {
+    sessionId: 'session-123',
+    turn: { notes: 'Updated notes' },
+  });
+
+  cleanup();
+});

--- a/src/utils/__tests__/rendererTestUtils.js
+++ b/src/utils/__tests__/rendererTestUtils.js
@@ -1,0 +1,146 @@
+const { mock } = require('node:test');
+
+function setupRendererGlobals() {
+  const previous = {
+    window: global.window,
+    document: global.document,
+    customElements: global.customElements,
+    localStorage: global.localStorage,
+    logger: global.logger,
+    crypto: global.crypto,
+    self: global.self,
+    navigator: global.navigator,
+    HTMLElement: global.HTMLElement,
+    DocumentFragment: global.DocumentFragment,
+  };
+
+  const storage = new Map();
+  const localStorage = {
+    getItem: key => (storage.has(key) ? storage.get(key) : null),
+    setItem: (key, value) => {
+      storage.set(key, String(value));
+    },
+    removeItem: key => {
+      storage.delete(key);
+    },
+    clear: () => {
+      storage.clear();
+    },
+  };
+
+  const classList = {
+    add: mock.fn(),
+    remove: mock.fn(),
+    contains: mock.fn(() => false),
+  };
+
+  global.localStorage = localStorage;
+  global.self = global;
+  global.crypto = { randomUUID: () => 'test-uuid' };
+  global.HTMLElement = global.HTMLElement || class {};
+  global.logger = {
+    info: mock.fn(),
+    warn: mock.fn(),
+    error: mock.fn(),
+  };
+  const createElement = tag => ({
+    nodeName: String(tag || '').toUpperCase(),
+    style: {},
+    childNodes: [],
+    appendChild(node) {
+      this.childNodes.push(node);
+      return node;
+    },
+    removeChild(node) {
+      this.childNodes = this.childNodes.filter(child => child !== node);
+      return node;
+    },
+    setAttribute() {},
+    removeAttribute() {},
+  });
+
+  global.document = {
+    documentElement: { classList },
+    body: {
+      appendChild: () => {},
+      removeChild: () => {},
+    },
+    createElement,
+    createTextNode: text => ({ textContent: text }),
+    createComment: text => ({ textContent: text }),
+    createTreeWalker: () => ({
+      currentNode: null,
+      nextNode: () => null,
+    }),
+    importNode: node => node,
+  };
+
+  global.DocumentFragment = class {
+    constructor() {
+      this.childNodes = [];
+    }
+    appendChild(node) {
+      this.childNodes.push(node);
+      return node;
+    }
+  };
+
+  const registry = new Map();
+  global.customElements = {
+    define: (name, ctor) => {
+      registry.set(name, ctor);
+    },
+    get: name => registry.get(name),
+  };
+
+  const windowStub = previous.window || {};
+  windowStub.localStorage = localStorage;
+  windowStub.electron = windowStub.electron || {};
+  windowStub.salesWizard = windowStub.salesWizard || {};
+  windowStub.HTMLElement = global.HTMLElement;
+  windowStub.document = global.document;
+  windowStub.Node = windowStub.Node || class {};
+  windowStub.NodeFilter = windowStub.NodeFilter || { SHOW_ELEMENT: 1 };
+  windowStub.DocumentFragment = global.DocumentFragment;
+  global.window = windowStub;
+  global.navigator = global.navigator || { userAgent: 'node' };
+
+  return {
+    storage,
+    localStorage,
+    classList,
+    cleanup: () => {
+      if (previous.window === undefined) delete global.window;
+      else global.window = previous.window;
+
+      if (previous.document === undefined) delete global.document;
+      else global.document = previous.document;
+
+      if (previous.customElements === undefined) delete global.customElements;
+      else global.customElements = previous.customElements;
+
+      if (previous.localStorage === undefined) delete global.localStorage;
+      else global.localStorage = previous.localStorage;
+
+      if (previous.logger === undefined) delete global.logger;
+      else global.logger = previous.logger;
+
+      if (previous.crypto === undefined) delete global.crypto;
+      else global.crypto = previous.crypto;
+
+      if (previous.HTMLElement === undefined) delete global.HTMLElement;
+      else global.HTMLElement = previous.HTMLElement;
+
+      if (previous.DocumentFragment === undefined) delete global.DocumentFragment;
+      else global.DocumentFragment = previous.DocumentFragment;
+
+      if (previous.self === undefined) delete global.self;
+      else global.self = previous.self;
+
+      if (previous.navigator === undefined) delete global.navigator;
+      else global.navigator = previous.navigator;
+    },
+  };
+}
+
+module.exports = { setupRendererGlobals };

--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -4,6 +4,35 @@ const conversationStore = require('./conversationStore');
 const audioHandler = require('./audioHandler');
 const reconnection = require('./reconnection');
 const sessionManager = require('./sessionManager');
+const { resolveBackendOrigin } = require('../services/backendConfig.js');
+
+const API_BASE = resolveBackendOrigin();
+
+async function fetchJson(url, options = {}) {
+    const response = await fetch(url, {
+        ...options,
+        headers: {
+            'Content-Type': 'application/json',
+            ...(options.headers || {}),
+        },
+    });
+
+    if (!response.ok) {
+        const message = `Request failed with status ${response.status}`;
+        throw new Error(message);
+    }
+
+    if (response.status === 204) {
+        return null;
+    }
+
+    try {
+        return await response.json();
+    } catch (error) {
+        logger.warn('Failed to parse JSON response:', error);
+        return null;
+    }
+}
 
 function setupGeminiIpcHandlers(geminiSessionRef) {
     global.geminiSessionRef = geminiSessionRef;
@@ -120,6 +149,87 @@ function setupGeminiIpcHandlers(geminiSessionRef) {
             return { success: true };
         } catch (error) {
             logger.error('Error updating Google Search setting:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
+    ipcMain.handle('history:list', async () => {
+        try {
+            const data = await fetchJson(`${API_BASE}/history`);
+            return { success: true, data: Array.isArray(data) ? data : [] };
+        } catch (error) {
+            logger.error('Error listing history sessions:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
+    ipcMain.handle('history:get', async (_event, sessionId) => {
+        if (!sessionId) {
+            return { success: false, error: 'Session ID is required' };
+        }
+
+        try {
+            const data = await fetchJson(`${API_BASE}/history/${sessionId}`);
+            return { success: true, data };
+        } catch (error) {
+            logger.error('Error retrieving history session:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
+    ipcMain.handle('history:clear', async () => {
+        try {
+            await fetchJson(`${API_BASE}/history`, { method: 'DELETE' });
+            return { success: true };
+        } catch (error) {
+            logger.error('Error clearing history:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
+    ipcMain.handle('history:set-limit', async (_event, limit) => {
+        try {
+            await fetchJson(`${API_BASE}/history/limit`, {
+                method: 'PUT',
+                body: JSON.stringify({ limit }),
+            });
+            return { success: true };
+        } catch (error) {
+            logger.error('Error setting history limit:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
+    ipcMain.handle('history:add-turn', async (_event, { sessionId, turn }) => {
+        if (!sessionId || !turn) {
+            return { success: false, error: 'sessionId and turn payload are required' };
+        }
+
+        try {
+            await fetchJson(`${API_BASE}/history/${sessionId}/turn`, {
+                method: 'POST',
+                body: JSON.stringify(turn),
+            });
+            return { success: true };
+        } catch (error) {
+            logger.error('Error appending history turn:', error);
+            return { success: false, error: error.message };
+        }
+    });
+
+    ipcMain.handle('assistant:ask', async (_event, prompt) => {
+        if (!prompt) {
+            return { success: false, error: 'Prompt is required' };
+        }
+
+        try {
+            const data = await fetchJson(`${API_BASE}/ask`, {
+                method: 'POST',
+                body: JSON.stringify({ prompt }),
+            });
+            return { success: true, data };
+        } catch (error) {
+            logger.error('Error requesting assistant reply:', error);
             return { success: false, error: error.message };
         }
     });


### PR DESCRIPTION
## Summary
- add main-process IPC handlers for history retrieval, updates, and assistant text prompts alongside context get/set channels
- expose new IPC bridges in the preload script and refactor HistoryView and SalesWizardApp to consume `window.electron` helpers instead of direct fetch calls
- introduce renderer-focused tests with IPC stubs to cover HistoryView loading/selecting behaviour and SalesWizardApp state transitions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7e69c02988331937847bcdf43facb