### PR TITLE
Improve live streaming error handling

### DIFF
--- a/apps/desktop/src/services/llmClient.ts
+++ b/apps/desktop/src/services/llmClient.ts
@@ -6,6 +6,13 @@ const DEFAULT_WS = (import.meta.env.VITE_SERVER_URL || 'http://localhost:8787')
   .replace('http', 'ws')
   .replace('https', 'wss') + '/ws/live';
 
+const MAX_PAYLOAD_LOG_LENGTH = 512;
+
+const describePayload = (payload: string): string =>
+  payload.length > MAX_PAYLOAD_LOG_LENGTH ? `${payload.slice(0, MAX_PAYLOAD_LOG_LENGTH)}…` : payload;
+
+const getLogger = (): Console => ((globalThis as any)?.logger as Console) || console;
+
 export interface LLMClientOptions {
   url?: string;
 }
@@ -70,8 +77,8 @@ export class LLMClient {
         this.ws.onopen = () => {
           opened = true;
           clearTimeout(timeout);
-          this._send({ type: 'start', model, responseModalities, systemInstruction });
           this.onStatus('WS open');
+          this._send({ type: 'start', model, responseModalities, systemInstruction });
           resolve(true);
         };
         this.ws.onclose = () => {
@@ -107,11 +114,38 @@ export class LLMClient {
   }
 
   private _send(obj: OutgoingMessage): void {
+    const log = getLogger();
+    let payload: string;
     try {
-      if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-        this.ws.send(JSON.stringify(obj));
-      }
-    } catch {}
+      payload = JSON.stringify(obj);
+    } catch (err: any) {
+      const msg = `Unable to serialise payload for send: ${err?.message || err}`;
+      log.error(msg, err);
+      this.onError(msg);
+      return;
+    }
+
+    if (!this.ws) {
+      const msg = `Cannot send message, WebSocket not initialised. Payload: ${describePayload(payload)}`;
+      log.warn(msg);
+      this.onError(msg);
+      return;
+    }
+
+    if (this.ws.readyState !== WebSocket.OPEN) {
+      const msg = `Cannot send message, WebSocket state ${this.ws.readyState}. Payload: ${describePayload(payload)}`;
+      log.warn(msg);
+      this.onError(msg);
+      return;
+    }
+
+    try {
+      this.ws.send(payload);
+    } catch (err: any) {
+      const msg = `WebSocket send failed: ${err?.message || err}. Payload: ${describePayload(payload)}`;
+      log.error(msg, err);
+      this.onError(msg);
+    }
   }
 
   sendText(text: string): void {

--- a/src/services/llmClient.js
+++ b/src/services/llmClient.js
@@ -2,8 +2,18 @@
 // Mirrors the desktop implementation but with browser-friendly defaults.
 
 import { resolveLiveWsUrl } from './backendConfig.js';
+import defaultLogger from '../utils/logger.js';
 
 const DEFAULT_WS = resolveLiveWsUrl();
+const getLogger = () => globalThis.logger || defaultLogger || console;
+const MAX_PAYLOAD_LOG_LENGTH = 512;
+
+const describePayload = payload => {
+    if (typeof payload !== 'string') return '[unserializable payload]';
+    return payload.length > MAX_PAYLOAD_LOG_LENGTH
+        ? `${payload.slice(0, MAX_PAYLOAD_LOG_LENGTH)}…`
+        : payload;
+};
 
 export class LLMClient {
     /** @type {WebSocket|null} */
@@ -43,13 +53,13 @@ export class LLMClient {
                     opened = true;
                     clearTimeout(timeout);
                     const instr = systemInstruction || this._buildSystemInstruction();
+                    this.onStatus('WS open');
                     this._send({
                         type: 'start',
                         model,
                         responseModalities,
                         systemInstruction: instr,
                     });
-                    this.onStatus('WS open');
                     resolve(true);
                 };
                 this.ws.onclose = () => {
@@ -103,12 +113,39 @@ export class LLMClient {
     }
 
     _send(obj) {
+        const log = getLogger();
+        let payload;
         try {
-            if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-                this.ws.send(JSON.stringify(obj));
-            }
-        } catch (e) {
-            /* empty */
+            payload = JSON.stringify(obj);
+        } catch (err) {
+            const msg = `Unable to serialise payload for send: ${err?.message || err}`;
+            log.error(msg, err);
+            this.onError(msg);
+            return;
+        }
+
+        const payloadPreview = describePayload(payload);
+
+        if (!this.ws) {
+            const msg = `Cannot send message, WebSocket not initialised. Payload: ${payloadPreview}`;
+            log.warn(msg);
+            this.onError(msg);
+            return;
+        }
+
+        if (this.ws.readyState !== WebSocket.OPEN) {
+            const msg = `Cannot send message, WebSocket state ${this.ws.readyState}. Payload: ${payloadPreview}`;
+            log.warn(msg);
+            this.onError(msg);
+            return;
+        }
+
+        try {
+            this.ws.send(payload);
+        } catch (err) {
+            const msg = `WebSocket send failed: ${err?.message || err}. Payload: ${payloadPreview}`;
+            log.error(msg, err);
+            this.onError(msg);
         }
     }
 

--- a/src/utils/__tests__/liveStreamer.test.js
+++ b/src/utils/__tests__/liveStreamer.test.js
@@ -8,9 +8,13 @@ global.WebSocket = class {
     setImmediate(() => this.onopen && this.onopen());
   }
   send() {}
-  close() { if (this.onclose) this.onclose(); }
+  close() {
+    this.readyState = global.WebSocket.CLOSED;
+    if (this.onclose) this.onclose();
+  }
 };
 global.WebSocket.OPEN = 1;
+global.WebSocket.CLOSED = 3;
 
 // Use real startLiveStreaming with stubbed WebSocket
 const { startLiveStreaming } = require('../liveStreamer');
@@ -21,6 +25,119 @@ function restoreTimers(orig) {
   global.setInterval = orig.setInterval;
   global.clearInterval = orig.clearInterval;
 }
+
+test('LLMClient emits error when socket is not open', () => {
+  global.logger = { warn: mock.fn(), error: mock.fn(), info: mock.fn(), debug: mock.fn() };
+
+  const client = new LLMClient();
+  const errors = [];
+  client.onError = msg => errors.push(msg);
+
+  const sendMock = mock.fn();
+  client.ws = { readyState: global.WebSocket.CLOSED, send: sendMock };
+
+  client.sendText('hello');
+
+  assert.strictEqual(sendMock.mock.callCount(), 0, 'send should not be attempted when socket is closed');
+  assert.strictEqual(errors.length, 1, 'onError should be invoked once');
+  assert.match(errors[0], /state/i);
+  assert.match(errors[0], /hello/);
+  assert.ok(global.logger.warn.mock.callCount() >= 1, 'warning should be logged');
+});
+
+test('LLMClient surfaces send exceptions with payload context', () => {
+  global.logger = { warn: mock.fn(), error: mock.fn(), info: mock.fn(), debug: mock.fn() };
+
+  const client = new LLMClient();
+  const errors = [];
+  client.onError = msg => errors.push(msg);
+
+  const sendMock = mock.fn(() => { throw new Error('boom'); });
+  client.ws = { readyState: global.WebSocket.OPEN, send: sendMock };
+
+  client.sendText('payload-check');
+
+  assert.strictEqual(sendMock.mock.callCount(), 1, 'send should be attempted once');
+  assert.strictEqual(errors.length, 1, 'onError should be invoked once');
+  assert.match(errors[0], /boom/);
+  assert.match(errors[0], /payload-check/);
+  assert.ok(global.logger.error.mock.callCount() >= 1, 'error should be logged');
+});
+
+test('startLiveStreaming propagates client send failure and stops streaming', async () => {
+  const origWebSocket = global.WebSocket;
+  const origOpen = global.WebSocket.OPEN;
+  const origClosed = global.WebSocket.CLOSED;
+  const origNavigator = global.navigator;
+  const origImageCapture = global.ImageCapture;
+  const origLogger = global.logger;
+  const origTimers = { setInterval, clearInterval };
+
+  global.logger = { warn: mock.fn(), error: mock.fn(), info: mock.fn(), debug: mock.fn() };
+
+  class FailingWebSocket {
+    constructor() {
+      this.readyState = FailingWebSocket.OPEN;
+      setImmediate(() => this.onopen && this.onopen());
+    }
+    send() {
+      this.readyState = FailingWebSocket.CLOSED;
+      throw new Error('Simulated send failure');
+    }
+    close() {
+      this.readyState = FailingWebSocket.CLOSED;
+      if (this.onclose) this.onclose();
+    }
+  }
+  FailingWebSocket.OPEN = 1;
+  FailingWebSocket.CLOSED = 3;
+
+  global.WebSocket = FailingWebSocket;
+  global.WebSocket.OPEN = FailingWebSocket.OPEN;
+  global.WebSocket.CLOSED = FailingWebSocket.CLOSED;
+
+  const getDisplayMedia = mock.fn(async () => ({ getVideoTracks: () => [], getTracks: () => [] }));
+  global.navigator = {
+    mediaDevices: {
+      getUserMedia: mock.fn(async () => { throw new Error('no audio'); }),
+      getDisplayMedia,
+    },
+  };
+
+  global.ImageCapture = class { constructor() {} };
+
+  global.setInterval = mock.fn(() => 123);
+  global.clearInterval = mock.fn();
+
+  const onStatus = mock.fn();
+  const onError = mock.fn();
+
+  try {
+    const stopFn = await startLiveStreaming({ onResponse: () => {}, onStatus, onError });
+
+    assert.strictEqual(getDisplayMedia.mock.callCount(), 0, 'screen capture should not start after fatal error');
+    assert.ok(onError.mock.callCount() >= 1, 'onError should be triggered');
+    const errorMessage = onError.mock.calls[0].arguments[0];
+    assert.match(errorMessage, /WebSocket send failed/, 'error should mention send failure');
+
+    const statusMessages = onStatus.mock.calls.map(call => call.arguments[0]);
+    assert.ok(statusMessages.includes('WS open'), 'should report WS open status');
+    assert.ok(statusMessages.some(msg => /^Error: /.test(msg)), 'error status should be reported');
+    assert.strictEqual(statusMessages.at(-1), 'Screen capture ended', 'cleanup status should be emitted');
+
+    stopFn();
+
+    assert.ok(global.logger.error.mock.callCount() >= 1, 'logger should record the failure');
+  } finally {
+    global.WebSocket = origWebSocket;
+    global.WebSocket.OPEN = origOpen;
+    global.WebSocket.CLOSED = origClosed;
+    if (origNavigator === undefined) delete global.navigator; else global.navigator = origNavigator;
+    if (origImageCapture === undefined) delete global.ImageCapture; else global.ImageCapture = origImageCapture;
+    if (origLogger === undefined) delete global.logger; else global.logger = origLogger;
+    restoreTimers(origTimers);
+  }
+});
 
 test('screen track end stops interval and notifies status', async () => {
   global.logger = { warn: mock.fn(), error: mock.fn(), info: mock.fn() };

--- a/src/utils/liveStreamer.js
+++ b/src/utils/liveStreamer.js
@@ -3,7 +3,7 @@ import defaultLogger from './logger.js';
 import { generateNotesFromResponse } from './summarizer.js';
 
 // Fallback to console if the logger script fails to attach to globalThis
-const logger = globalThis.logger || defaultLogger || console;
+const getLogger = () => globalThis.logger || defaultLogger || console;
 
 /**
  * Starts streaming microphone audio and screen captures to the backend
@@ -25,6 +25,38 @@ export async function startLiveStreaming({
   onNote = () => {},
 }) {
   const client = new LLMClient();
+  const log = getLogger();
+  let audioCleanup = () => {};
+  let stopScreenCapture = () => { onStatus('Screen capture ended'); };
+  let stopped = false;
+
+  const safeCall = (label, fn) => {
+    try {
+      fn?.();
+    } catch (err) {
+      log.warn(`${label} failed:`, err);
+    }
+  };
+
+  const stopAll = () => {
+    if (stopped) return;
+    stopped = true;
+    const ws = client.ws;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      safeCall('Ending live session', () => client.end());
+    } else {
+      safeCall('Closing WebSocket session', () => {
+        try {
+          ws?.close?.();
+        } catch (err) {
+          log.warn('WebSocket close failed:', err);
+        }
+      });
+    }
+    safeCall('Cleaning audio stream', () => audioCleanup());
+    safeCall('Cleaning screen capture', () => stopScreenCapture());
+  };
+
   client.onText = msg => {
     try {
       if (typeof msg === 'string') {
@@ -37,16 +69,28 @@ export async function startLiveStreaming({
         }
       }
     } catch (err) {
-      logger.warn('Error handling text:', err);
+      log.warn('Error handling text:', err);
     }
   };
   client.onStatus = onStatus;
-  client.onError = onError;
+  client.onError = err => {
+    const message = typeof err === 'string' ? err : err?.message ? err.message : String(err);
+    log.error('Live streaming client error:', err ?? message);
+    onError(message);
+    if (!stopped) {
+      onStatus(`Error: ${message}`);
+      stopAll();
+    }
+  };
 
   await client.connect();
 
+  if (stopped) {
+    return stopAll;
+  }
+
   // Audio capture
-  let audioStream; let audioCleanup = () => {};
+  let audioStream;
   try {
     audioStream = await navigator.mediaDevices.getUserMedia({ audio: true });
     const audioCtx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 16000 });
@@ -133,7 +177,7 @@ export async function startLiveStreaming({
       };
     }
   } catch (err) {
-    logger.warn('Audio streaming failed to initialise:', err);
+    log.warn('Audio streaming failed to initialise:', err);
   }
 
   // Screen capture
@@ -161,7 +205,7 @@ export async function startLiveStreaming({
     disposableNodes.clear();
   };
 
-  const stopScreenCapture = () => {
+  stopScreenCapture = () => {
     if (frameInterval) {
       clearInterval(frameInterval);
       frameInterval = null;
@@ -270,7 +314,7 @@ export async function startLiveStreaming({
         try {
           videoElement.srcObject = screenStream;
         } catch (err) {
-          logger.warn('Unable to bind stream to video element:', err);
+          log.warn('Unable to bind stream to video element:', err);
         }
         const settings = track.getSettings?.() || {};
         if (settings.width) videoElement.width = settings.width;
@@ -321,7 +365,7 @@ export async function startLiveStreaming({
             await encodeBlobAndSend(blob);
             return;
           } catch (err) {
-            logger.warn('ImageCapture.takePhoto failed, attempting grabFrame fallback:', err);
+            log.warn('ImageCapture.takePhoto failed, attempting grabFrame fallback:', err);
             useGrabFrame = true;
           }
         }
@@ -333,7 +377,7 @@ export async function startLiveStreaming({
             await encodeBlobAndSend(blob);
             return;
           } catch (err) {
-            logger.warn('ImageCapture.grabFrame failed, attempting canvas fallback:', err);
+            log.warn('ImageCapture.grabFrame failed, attempting canvas fallback:', err);
             useCanvasFallback = true;
           }
         }
@@ -343,7 +387,7 @@ export async function startLiveStreaming({
           await encodeBlobAndSend(blob);
         }
       } catch (err) {
-        logger.warn('Error capturing screen frame:', err);
+        log.warn('Error capturing screen frame:', err);
       } finally {
         isCapturing = false;
       }
@@ -354,15 +398,13 @@ export async function startLiveStreaming({
     const msg = err?.name === 'NotAllowedError'
       ? 'Screen capture request was blocked or denied. Your browser may require a reload before prompting again.'
       : `Screen streaming failed to initialise: ${err?.message || err}`;
-    logger.warn(msg, err);
+    log.warn(msg, err);
     onError(msg);
+    onStatus(`Error: ${msg}`);
     stopScreenCapture();
+    stopAll();
   }
 
-  return () => {
-    client.end();
-    audioCleanup();
-    stopScreenCapture();
-  };
+  return stopAll;
 }
 


### PR DESCRIPTION
## Summary
- add contextual logging and error propagation in both LLM client implementations when WebSocket sends fail or sockets are unavailable
- make startLiveStreaming react to client errors by reporting status updates and performing a unified cleanup routine
- extend the live streamer unit suite to cover send failures and ensure cleanup occurs

## Testing
- npm test -- src/utils/__tests__/liveStreamer.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e7e6a00ad8833182dfb591962d2bb2