### PR TITLE
Handle SystemAudioDump launch errors and add tests

### DIFF
--- a/src/utils/__tests__/audioHandler.test.js
+++ b/src/utils/__tests__/audioHandler.test.js
@@ -1,6 +1,81 @@
-const { test } = require('node:test');
+const { test, mock } = require('node:test');
 const assert = require('node:assert');
-const { convertStereoToMono, computeEnergyFromBase64Pcm16 } = require('../audioHandler');
+const path = require('node:path');
+const mockFs = require('mock-fs');
+const childProcess = require('child_process');
+const audioHandler = require('../audioHandler');
+const ipcUtils = require('../ipcUtils');
+
+const { convertStereoToMono, computeEnergyFromBase64Pcm16, startMacOSAudioCapture } = audioHandler;
+
+function stubPlatform(t, platform) {
+    const descriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { ...descriptor, value: platform });
+    t.after(() => Object.defineProperty(process, 'platform', descriptor));
+}
+
+function stubElectron(t, overrides = {}) {
+    const electronPath = require.resolve('electron');
+    const original = require.cache[electronPath];
+    require.cache[electronPath] = { exports: { app: { isPackaged: false, ...overrides } } };
+    t.after(() => {
+        if (original) {
+            require.cache[electronPath] = original;
+        } else {
+            delete require.cache[electronPath];
+        }
+    });
+}
+
+function stubLogger(t) {
+    const originalLogger = global.logger;
+    global.logger = {
+        error: mock.fn(),
+        warn: mock.fn(),
+        info: mock.fn(),
+        debug: mock.fn(),
+    };
+    t.after(() => {
+        global.logger = originalLogger;
+    });
+}
+
+function stubSendToRenderer(t) {
+    const statusSpy = mock.fn();
+    const originalSend = ipcUtils.sendToRenderer;
+    ipcUtils.sendToRenderer = statusSpy;
+    t.after(() => {
+        ipcUtils.sendToRenderer = originalSend;
+    });
+    return statusSpy;
+}
+
+function stubSpawn(t, implementation) {
+    const originalSpawn = childProcess.spawn;
+    childProcess.spawn = implementation;
+    t.after(() => {
+        childProcess.spawn = originalSpawn;
+    });
+}
+
+function mockKillProcess() {
+    const listeners = {};
+    return {
+        pid: 111,
+        on(event, handler) {
+            listeners[event] = handler;
+            if (event === 'close') {
+                setImmediate(() => handler(0, null));
+            }
+            return this;
+        },
+        kill() {
+            if (listeners.close) listeners.close(0, null);
+        },
+        stdout: { on() {} },
+        stderr: { on() {} },
+    };
+}
 
 test('convertStereoToMono converts buffer', () => {
     const stereo = Buffer.alloc(8);
@@ -21,4 +96,59 @@ test('computeEnergyFromBase64Pcm16 calculates average amplitude', () => {
     const base64 = buf.toString('base64');
     const energy = computeEnergyFromBase64Pcm16(base64);
     assert.strictEqual(energy, 1000);
+});
+
+test('startMacOSAudioCapture notifies when SystemAudioDump binary is missing', async t => {
+    stubPlatform(t, 'darwin');
+    stubElectron(t);
+    stubLogger(t);
+    const statusSpy = stubSendToRenderer(t);
+
+    stubSpawn(t, mock.fn(command => {
+        if (command === 'pkill') {
+            return mockKillProcess();
+        }
+        throw new Error(`Unexpected spawn command: ${command}`);
+    }));
+
+    mockFs({});
+    t.after(() => mockFs.restore());
+
+    const result = await startMacOSAudioCapture({ current: null });
+    assert.strictEqual(result, false);
+    assert.ok(statusSpy.mock.callCount() > 0);
+    const lastStatus = statusSpy.mock.calls.at(-1).arguments;
+    assert.deepStrictEqual(lastStatus[0], 'update-status');
+    assert.match(lastStatus[1], /binary not found/i);
+});
+
+test('startMacOSAudioCapture surfaces spawn errors to the renderer', async t => {
+    stubPlatform(t, 'darwin');
+    stubElectron(t);
+    stubLogger(t);
+    const statusSpy = stubSendToRenderer(t);
+
+    const spawnError = new Error('spawn failure');
+    stubSpawn(t, mock.fn((command, args, options) => {
+        if (command === 'pkill') {
+            return mockKillProcess();
+        }
+        throw spawnError;
+    }));
+
+    const assetsDir = path.join(__dirname, '../../assets');
+    mockFs({
+        [assetsDir]: {
+            SystemAudioDump: mockFs.file({ mode: 0o755, content: '' }),
+        },
+    });
+    t.after(() => mockFs.restore());
+
+    const result = await startMacOSAudioCapture({ current: null });
+    assert.strictEqual(result, false);
+    assert.strictEqual(childProcess.spawn.mock.callCount(), 2);
+    const lastStatus = statusSpy.mock.calls.at(-1).arguments;
+    assert.deepStrictEqual(lastStatus[0], 'update-status');
+    assert.match(lastStatus[1], /Error starting system audio capture/i);
+    assert.match(lastStatus[1], /spawn failure/i);
 });

--- a/src/utils/audioHandler.js
+++ b/src/utils/audioHandler.js
@@ -1,5 +1,8 @@
-const { spawn } = require('child_process');
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
 const { saveDebugAudio } = require('../audioUtils');
+const ipcUtils = require('./ipcUtils');
 
 let systemAudioProc = null;
 let vadSpeaking = false;
@@ -10,7 +13,7 @@ const VAD_SILENCE_SEND_MS = 2500;
 
 function killExistingSystemAudioDump() {
     return new Promise(resolve => {
-        const killProc = spawn('pkill', ['-f', 'SystemAudioDump'], { stdio: 'ignore' });
+        const killProc = childProcess.spawn('pkill', ['-f', 'SystemAudioDump'], { stdio: 'ignore' });
         killProc.on('close', () => resolve());
         killProc.on('error', () => resolve());
         setTimeout(() => {
@@ -25,13 +28,24 @@ async function startMacOSAudioCapture(geminiSessionRef) {
     await killExistingSystemAudioDump();
 
     const { app } = require('electron');
-    const path = require('path');
 
     let systemAudioPath;
     if (app.isPackaged) {
         systemAudioPath = path.join(process.resourcesPath, 'SystemAudioDump');
     } else {
         systemAudioPath = path.join(__dirname, '../assets', 'SystemAudioDump');
+    }
+
+    try {
+        await fs.promises.access(systemAudioPath, fs.constants.X_OK);
+    } catch (err) {
+        const message =
+            err.code === 'ENOENT'
+                ? 'Error: SystemAudioDump binary not found. Install it to enable system audio capture.'
+                : 'Error: SystemAudioDump binary is not executable. Check permissions.';
+        logger.error('SystemAudioDump binary validation failed:', err);
+        ipcUtils.sendToRenderer('update-status', message);
+        return false;
     }
 
     const spawnOptions = {
@@ -44,9 +58,17 @@ async function startMacOSAudioCapture(geminiSessionRef) {
         spawnOptions.windowsHide = false;
     }
 
-    systemAudioProc = spawn(systemAudioPath, [], spawnOptions);
-    if (!systemAudioProc.pid) {
+    try {
+        systemAudioProc = childProcess.spawn(systemAudioPath, [], spawnOptions);
+    } catch (err) {
+        logger.error('Failed to start SystemAudioDump:', err);
+        ipcUtils.sendToRenderer('update-status', `Error starting system audio capture: ${err.message}`);
+        return false;
+    }
+
+    if (!systemAudioProc?.pid) {
         logger.error('Failed to start SystemAudioDump');
+        ipcUtils.sendToRenderer('update-status', 'Error starting system audio capture: SystemAudioDump failed to launch.');
         return false;
     }
 
@@ -77,15 +99,22 @@ async function startMacOSAudioCapture(geminiSessionRef) {
     });
 
     systemAudioProc.stderr.on('data', data => {
-        logger.error('SystemAudioDump stderr:', data.toString());
+        const stderrOutput = data.toString();
+        logger.error('SystemAudioDump stderr:', stderrOutput);
+        ipcUtils.sendToRenderer('update-status', `SystemAudioDump stderr: ${stderrOutput.trim()}`);
     });
 
-    systemAudioProc.on('close', () => {
+    systemAudioProc.on('close', (code, signal) => {
         systemAudioProc = null;
+        if (code !== 0) {
+            const reason = signal ? ` (signal: ${signal})` : '';
+            ipcUtils.sendToRenderer('update-status', `SystemAudioDump exited with code ${code}${reason}`);
+        }
     });
 
     systemAudioProc.on('error', err => {
         logger.error('SystemAudioDump process error:', err);
+        ipcUtils.sendToRenderer('update-status', `SystemAudioDump process error: ${err.message}`);
         systemAudioProc = null;
     });
 


### PR DESCRIPTION
## Summary
- validate the SystemAudioDump binary before spawning and surface renderer-visible errors when startup fails
- forward stderr output, non-zero exits, and spawn errors via update-status events to aid debugging
- add mock-fs based unit tests that cover missing binary and spawn failure scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7e6a01f188331951f4c4e107184e3