### PR TITLE
Enforce backend auth token and origin checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,33 @@ By default the server listens on port 3001 (or the value of the `PORT` environme
   backend accepts calls from any origin; otherwise, disallowed origins are rejected with `403` before reaching your
   handlers.
 
+### Authorized request examples
+
+```js
+// HTTP example
+await fetch('http://localhost:3001/ask', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    AUTH_TOKEN: process.env.AUTH_TOKEN,
+    Origin: 'http://localhost:3000',
+  },
+  body: JSON.stringify({ prompt: 'Hello there!' }),
+});
+
+// WebSocket example
+const ws = new WebSocket('ws://localhost:3001/live', {
+  headers: {
+    AUTH_TOKEN: process.env.AUTH_TOKEN,
+    Origin: 'http://localhost:3000',
+  },
+});
+
+ws.onopen = () => {
+  ws.send(JSON.stringify({ text: 'Ready to stream' }));
+};
+```
+
 ## API Endpoints
 
 ### `/history`

--- a/backend/__tests__/auth.test.js
+++ b/backend/__tests__/auth.test.js
@@ -1,69 +1,189 @@
 const test = require('node:test');
-const assert = require('node:assert');
+const assert = require('node:assert/strict');
+const WebSocket = require('ws');
+const { createBackend } = require('../server');
 
-process.env.AUTH_TOKEN = 'test-secret-token';
-process.env.ALLOWED_ORIGINS = 'http://allowed.test';
+const AUTH_TOKEN = 'test-secret-token';
+const ALLOWED_ORIGIN = 'http://allowed.test';
+
+process.env.AUTH_TOKEN = AUTH_TOKEN;
+process.env.ALLOWED_ORIGINS = ALLOWED_ORIGIN;
 process.env.PORT = 0;
 
-const { startServer } = require('../server');
+function createMockGenai({ replyText = 'Mock reply', responses = [{ text: 'streamed response' }] } = {}) {
+  const session = {
+    sentInputs: [],
+    closed: false,
+    async *receive() {
+      for (const response of responses) {
+        await new Promise(resolve => setImmediate(resolve));
+        yield response;
+      }
+    },
+    async send_realtime_input(payload) {
+      this.sentInputs.push(payload);
+      return { ok: true };
+    },
+    async close() {
+      this.closed = true;
+    },
+  };
 
-async function createServer(t) {
-  const { server, wss } = startServer({ port: 0 });
-  const address = server.address();
-  const baseUrl = `http://127.0.0.1:${address.port}`;
-
-  t.after(async () => {
-    await new Promise(resolve => wss.close(resolve));
-    await new Promise(resolve => server.close(resolve));
-  });
-
-  return { baseUrl };
+  return {
+    session,
+    genai: {
+      getGenerativeModel() {
+        return {
+          async generateContent() {
+            return {
+              candidates: [
+                {
+                  content: {
+                    parts: [{ text: replyText }],
+                  },
+                },
+              ],
+            };
+          },
+        };
+      },
+      live: {
+        async connect() {
+          return session;
+        },
+      },
+    },
+  };
 }
 
-test('rejects POST /ask without an auth token', async (t) => {
-  const { baseUrl } = await createServer(t);
+async function createServer(t, options = {}) {
+  const { genai, session } = createMockGenai(options);
+  const backend = createBackend({ genaiClient: genai, logger: console, port: 0 });
+  const server = backend.app.listen(0);
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : address;
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const wss = backend.attachLiveWebSocket(server);
+
+  t.after(() => new Promise(resolve => wss.close(resolve)));
+  t.after(() => new Promise(resolve => server.close(resolve)));
+
+  return { baseUrl, port, session };
+}
+
+test('allows POST /ask with valid credentials', async t => {
+  const { baseUrl } = await createServer(t, { replyText: 'Authorized reply' });
+
   const response = await fetch(`${baseUrl}/ask`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Origin: 'http://allowed.test'
+      AUTH_TOKEN,
+      Origin: ALLOWED_ORIGIN,
     },
-    body: JSON.stringify({ prompt: 'hello' })
+    body: JSON.stringify({ prompt: 'hello' }),
   });
 
-  assert.strictEqual(response.status, 401);
+  assert.equal(response.status, 200);
   const payload = await response.json();
-  assert.strictEqual(payload.error, 'Unauthorized');
+  assert.deepEqual(payload, { reply: 'Authorized reply' });
 });
 
-test('rejects history requests with an invalid token', async (t) => {
+test('rejects POST /ask without an auth token', async t => {
   const { baseUrl } = await createServer(t);
+
+  const response = await fetch(`${baseUrl}/ask`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: ALLOWED_ORIGIN,
+    },
+    body: JSON.stringify({ prompt: 'hello' }),
+  });
+
+  assert.equal(response.status, 401);
+  const payload = await response.json();
+  assert.equal(payload.error, 'Unauthorized');
+});
+
+test('rejects history requests with an invalid token', async t => {
+  const { baseUrl } = await createServer(t);
+
   const response = await fetch(`${baseUrl}/history`, {
     method: 'GET',
     headers: {
       AUTH_TOKEN: 'wrong-token',
-      Origin: 'http://allowed.test'
-    }
+      Origin: ALLOWED_ORIGIN,
+    },
   });
 
-  assert.strictEqual(response.status, 401);
+  assert.equal(response.status, 401);
   const payload = await response.json();
-  assert.strictEqual(payload.error, 'Unauthorized');
+  assert.equal(payload.error, 'Unauthorized');
 });
 
-test('rejects requests from disallowed origins before auth', async (t) => {
+test('rejects requests from disallowed origins before auth', async t => {
   const { baseUrl } = await createServer(t);
+
   const response = await fetch(`${baseUrl}/ask`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      AUTH_TOKEN: 'test-secret-token',
-      Origin: 'http://blocked.test'
+      AUTH_TOKEN,
+      Origin: 'http://blocked.test',
     },
-    body: JSON.stringify({ prompt: 'hello' })
+    body: JSON.stringify({ prompt: 'hello' }),
   });
 
-  assert.strictEqual(response.status, 403);
+  assert.equal(response.status, 403);
   const payload = await response.json();
-  assert.strictEqual(payload.error, 'Origin not allowed');
+  assert.equal(payload.error, 'Origin not allowed');
+});
+
+test('allows websocket connections with valid credentials', async t => {
+  const { port, session } = await createServer(t, {
+    responses: [{ text: 'streamed response' }],
+  });
+
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/live`, {
+    headers: {
+      AUTH_TOKEN,
+      Origin: ALLOWED_ORIGIN,
+    },
+  });
+
+  t.after(() => {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.terminate();
+    }
+  });
+
+  await new Promise((resolve, reject) => {
+    ws.once('open', resolve);
+    ws.once('error', reject);
+  });
+
+  const incoming = new Promise(resolve => {
+    ws.once('message', data => resolve(data.toString()));
+  });
+
+  const audioPayload = Buffer.from('abc');
+  ws.send(
+    JSON.stringify({
+      audio: audioPayload.toString('base64'),
+      mimeType: 'audio/test',
+    }),
+  );
+
+  const message = await incoming;
+  assert.deepEqual(JSON.parse(message), { text: 'streamed response' });
+
+  assert.equal(session.sentInputs.length, 1);
+  assert.deepEqual(session.sentInputs[0], {
+    audio: { data: audioPayload, mime_type: 'audio/test' },
+  });
+
+  ws.close();
+  await new Promise(resolve => ws.once('close', resolve));
+  assert.equal(session.closed, true);
 });

--- a/backend/__tests__/server.jest.test.js
+++ b/backend/__tests__/server.jest.test.js
@@ -3,6 +3,18 @@ const WebSocket = require('ws');
 const { createBackend } = require('../server');
 const { createMockGenai } = require('../../tests/fixtures/mockGenai');
 
+const AUTH_TOKEN = 'jest-secret-token';
+const ALLOWED_ORIGIN = 'http://localhost';
+
+beforeAll(() => {
+  process.env.AUTH_TOKEN = AUTH_TOKEN;
+  process.env.ALLOWED_ORIGINS = ALLOWED_ORIGIN;
+});
+
+function withAuth(req) {
+  return req.set('AUTH_TOKEN', AUTH_TOKEN).set('Origin', ALLOWED_ORIGIN);
+}
+
 function createHistoryStore() {
   return {
     appendTurn: jest.fn(),
@@ -26,8 +38,10 @@ describe('backend/server', () => {
     const backend = createBackend({ logger, historyStoreImpl: historyStore, genaiClient: genai });
     const agent = request(backend.app);
 
-    await agent.put('/context-params').send({ allowedSources: 'Docs', toneLength: 'Short' }).expect(200);
-    const response = await agent.get('/context-params').expect(200);
+    await withAuth(agent.put('/context-params'))
+      .send({ allowedSources: 'Docs', toneLength: 'Short' })
+      .expect(200);
+    const response = await withAuth(agent.get('/context-params')).expect(200);
     expect(response.body).toEqual({
       allowedSources: 'Docs',
       toneLength: 'Short',
@@ -45,7 +59,7 @@ describe('backend/server', () => {
     const backend = createBackend({ logger, historyStoreImpl: historyStore, genaiClient: genai });
     const agent = request(backend.app);
 
-    const res = await agent.post('/ask').send({ prompt: 'Hi' }).expect(200);
+    const res = await withAuth(agent.post('/ask')).send({ prompt: 'Hi' }).expect(200);
     expect(res.body).toEqual({ reply: 'Hello there' });
     expect(backend.state.history).toEqual([{ prompt: 'Hi', reply: 'Hello there' }]);
   });
@@ -58,7 +72,7 @@ describe('backend/server', () => {
     const backend = createBackend({ logger, historyStoreImpl: historyStore, genaiClient: genai });
     const agent = request(backend.app);
 
-    const res = await agent.post('/ask').send({ prompt: 'Hi' }).expect(500);
+    const res = await withAuth(agent.post('/ask')).send({ prompt: 'Hi' }).expect(500);
     expect(res.body).toEqual({ error: 'Generation failed' });
     expect(logger.error).toHaveBeenCalledWith('Error:', error);
   });
@@ -68,19 +82,19 @@ describe('backend/server', () => {
     const backend = createBackend({ logger, historyStoreImpl: historyStore, genaiClient: createMockGenai().genai });
     const agent = request(backend.app);
 
-    await agent.post('/history/test-session/turn').send({ role: 'user' }).expect(200);
+    await withAuth(agent.post('/history/test-session/turn')).send({ role: 'user' }).expect(200);
     expect(historyStore.appendTurn).toHaveBeenCalledWith('test-session', { role: 'user' });
 
-    await agent.delete('/history').expect(200);
+    await withAuth(agent.delete('/history')).expect(200);
     expect(historyStore.clearHistory).toHaveBeenCalled();
 
-    await agent.get('/history').expect(200);
+    await withAuth(agent.get('/history')).expect(200);
     expect(historyStore.listSessions).toHaveBeenCalled();
 
-    await agent.put('/history/limit').send({ limit: 10 }).expect(200);
+    await withAuth(agent.put('/history/limit')).send({ limit: 10 }).expect(200);
     expect(historyStore.setMaxSessions).toHaveBeenCalledWith(10);
 
-    const notFound = await agent.get('/history/unknown').expect(404);
+    const notFound = await withAuth(agent.get('/history/unknown')).expect(404);
     expect(notFound.body).toEqual({ error: 'Not found' });
   });
 
@@ -101,7 +115,12 @@ describe('backend/server', () => {
     const port = typeof address === 'object' ? address.port : 0;
     const wss = backend.attachLiveWebSocket(server);
 
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/live`);
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/live`, {
+      headers: {
+        AUTH_TOKEN,
+        Origin: ALLOWED_ORIGIN,
+      },
+    });
 
     await new Promise(resolve => ws.on('open', resolve));
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -18,6 +18,64 @@ function createBackend(options = {}) {
   const app = express();
   app.use(express.json());
 
+  const expectedToken = (process.env.AUTH_TOKEN || '').trim();
+  const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+    .split(',')
+    .map(origin => origin.trim())
+    .filter(Boolean);
+
+  function originAllowed(origin) {
+    if (!allowedOrigins.length) {
+      return true;
+    }
+    return typeof origin === 'string' && allowedOrigins.includes(origin);
+  }
+
+  function applyCorsHeaders(res, origin) {
+    if (originAllowed(origin) && origin) {
+      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('Vary', 'Origin');
+    }
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, AUTH_TOKEN, authToken, Authorization');
+    res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS,PATCH');
+  }
+
+  function extractHttpToken(req) {
+    return (
+      req.get('AUTH_TOKEN') ||
+      req.get('auth_token') ||
+      req.query?.authToken ||
+      req.query?.AUTH_TOKEN ||
+      ''
+    ).toString().trim();
+  }
+
+  app.use((req, res, next) => {
+    const origin = req.get('Origin') || req.get('origin');
+
+    if (!originAllowed(origin)) {
+      return res.status(403).json({ error: 'Origin not allowed' });
+    }
+
+    applyCorsHeaders(res, origin);
+
+    if (req.method === 'OPTIONS') {
+      return res.sendStatus(204);
+    }
+
+    if (!expectedToken) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const providedToken = extractHttpToken(req);
+    if (providedToken !== expectedToken) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    return next();
+  });
+
   const genai = genaiClient || new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || '' });
 
   // In-memory state for conversation history and context parameters
@@ -161,11 +219,86 @@ function createBackend(options = {}) {
     return session;
   }
 
+  function extractSocketToken(request) {
+    const headerToken =
+      request.headers['auth_token'] ||
+      request.headers['auth-token'] ||
+      request.headers['AUTH_TOKEN'];
+
+    if (headerToken) {
+      return headerToken.toString().trim();
+    }
+
+    try {
+      const url = new URL(request.url, `http://${request.headers.host}`);
+      return (
+        url.searchParams.get('authToken') ||
+        url.searchParams.get('AUTH_TOKEN') ||
+        ''
+      )
+        .toString()
+        .trim();
+    } catch (err) {
+      logger.error('Failed to parse WebSocket auth parameters:', err);
+      return '';
+    }
+  }
+
   function attachLiveWebSocket(serverInstance) {
-    const wss = new WebSocketServer({ server: serverInstance, path: '/live' });
+    const wss = new WebSocketServer({ noServer: true });
+
+    const upgradeListener = (request, socket, head) => {
+      let parsedUrl;
+      try {
+        parsedUrl = new URL(request.url, `http://${request.headers.host}`);
+      } catch (err) {
+        socket.write('HTTP/1.1 400 Bad Request\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
+      if (parsedUrl.pathname !== '/live') {
+        socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
+      const origin = request.headers.origin || request.headers.Origin;
+
+      if (!originAllowed(origin)) {
+        socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
+      if (!expectedToken) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
+      const token = extractSocketToken(request);
+      if (token !== expectedToken) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
+      wss.handleUpgrade(request, socket, head, ws => {
+        wss.emit('connection', ws, request);
+      });
+    };
+
+    serverInstance.on('upgrade', upgradeListener);
+
+    wss.on('close', () => {
+      serverInstance.removeListener('upgrade', upgradeListener);
+    });
+
     wss.on('connection', ws => {
       handleLiveConnection(ws).catch(err => logger.error('Failed to establish live session:', err));
     });
+
     return wss;
   }
 


### PR DESCRIPTION
## Summary
- add shared HTTP middleware that enforces AUTH_TOKEN credentials and allowed origins before reaching backend routes
- validate WebSocket upgrade requests with the same token and origin checks
- document the required headers in the README and extend auth tests to cover authorized HTTP and WebSocket flows

## Testing
- `node --test backend/__tests__/auth.test.js` *(fails: missing ws dependency in the environment)*
- `npm run test:backend` *(fails: jest binary unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed6416120c833186993baabf47e77d