### PR TITLE
Add startServer helper and tests

### DIFF
--- a/backend/__tests__/server.jest.test.js
+++ b/backend/__tests__/server.jest.test.js
@@ -1,6 +1,6 @@
 const request = require('supertest');
 const WebSocket = require('ws');
-const { createBackend } = require('../server');
+const { createBackend, startServer } = require('../server');
 const { createMockGenai } = require('../../tests/fixtures/mockGenai');
 
 function createHistoryStore() {
@@ -125,5 +125,30 @@ describe('backend/server', () => {
 
     await new Promise(resolve => wss.close(resolve));
     await new Promise(resolve => server.close(resolve));
+  });
+
+  test('startServer starts backend and returns cleanup handles', async () => {
+    const historyStore = createHistoryStore();
+    const { genai } = createMockGenai();
+
+    const { server, wss } = startServer({
+      logger,
+      historyStoreImpl: historyStore,
+      genaiClient: genai,
+      port: 0,
+    });
+
+    expect(server).toBeDefined();
+    expect(typeof server.close).toBe('function');
+    expect(wss).toBeDefined();
+    expect(typeof wss.close).toBe('function');
+    expect(server.listening).toBe(true);
+
+    await Promise.all([
+      new Promise(resolve => wss.close(resolve)),
+      new Promise(resolve => server.close(resolve)),
+    ]);
+
+    expect(server.listening).toBe(false);
   });
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -178,9 +178,13 @@ function createBackend(options = {}) {
   return { app, state, buildSystemInstruction, start, attachLiveWebSocket };
 }
 
-if (require.main === module) {
-  const { start } = createBackend();
-  start();
+function startServer(options = {}) {
+  const backend = createBackend(options);
+  return backend.start();
 }
 
-module.exports = { createBackend };
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = { createBackend, startServer };


### PR DESCRIPTION
## Summary
- add a startServer wrapper that instantiates the backend and calls its start helper
- export startServer alongside createBackend while keeping the CLI entry point executable
- extend backend unit tests to cover the startServer contract and cleanup behaviour

## Testing
- npm run test:backend *(fails: jest binary unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed6416fe0c8331887a1213f3c08114