### PR TITLE
feat: persist structured notes payload

### DIFF
--- a/src/components/app/SalesWizardApp.js
+++ b/src/components/app/SalesWizardApp.js
@@ -196,6 +196,44 @@ export class SalesWizardApp extends LitElement {
         this.updateLayoutMode();
     }
 
+    get notePayload() {
+        const manualNotes = typeof this.manualNotes === 'string' ? this.manualNotes : '';
+        const structuredNotes = Array.isArray(this.notes)
+            ? this.notes
+                  .map(note => {
+                      if (!note || typeof note !== 'object') return null;
+                      const text = typeof note.text === 'string' ? note.text.trim() : '';
+                      if (!text) {
+                          return null;
+                      }
+                      return {
+                          ...note,
+                          text,
+                          type: typeof note.type === 'string' && note.type ? note.type : 'auto',
+                          timestamp:
+                              typeof note.timestamp === 'number' && Number.isFinite(note.timestamp)
+                                  ? note.timestamp
+                                  : Date.now(),
+                      };
+                  })
+                  .filter(Boolean)
+            : [];
+
+        return {
+            notes: structuredNotes,
+            manualNotes,
+        };
+    }
+
+    get noteText() {
+        const { notes, manualNotes } = this.notePayload;
+        const structuredText = notes.map(note => note.text).join('\n');
+        if (manualNotes && structuredText) {
+            return `${manualNotes}\n\n${structuredText}`;
+        }
+        return manualNotes || structuredText || '';
+    }
+
     connectedCallback() {
         super.connectedCallback();
 
@@ -264,7 +302,7 @@ export class SalesWizardApp extends LitElement {
                         await this.persistHistoryTurn({
                             transcription: transcript,
                             ai_response: reply,
-                            notes: this.noteText,
+                            ...this.notePayload,
                         });
                     } catch (err) {
                         logger.error('Failed to post turn:', err);
@@ -668,7 +706,7 @@ export class SalesWizardApp extends LitElement {
         this.notes = [];
         this.manualNotes = '';
         try {
-            await this.persistHistoryTurn({ sessionStart: true, notes: '' });
+            await this.persistHistoryTurn({ sessionStart: true, ...this.notePayload });
         } catch (error) {
             logger.error('Failed to start session history:', error);
         }
@@ -737,19 +775,24 @@ export class SalesWizardApp extends LitElement {
 
     async handleStructuredNotesChange(e) {
         const updatedNotes = Array.isArray(e?.detail?.notes) ? e.detail.notes : [];
-        this.notes = updatedNotes.map(note => ({
-            ...note,
-            type: note.type || 'auto',
-            text: typeof note.text === 'string' ? note.text : '',
-            timestamp: typeof note.timestamp === 'number' ? note.timestamp : Date.now(),
-        }));
+        this.notes = updatedNotes
+            .filter(note => note && typeof note === 'object')
+            .map(note => ({
+                ...note,
+                type: typeof note.type === 'string' && note.type ? note.type : 'auto',
+                text: typeof note.text === 'string' ? note.text : '',
+                timestamp:
+                    typeof note.timestamp === 'number' && Number.isFinite(note.timestamp)
+                        ? note.timestamp
+                        : Date.now(),
+            }));
         await this.persistNotes();
     }
 
     async persistNotes() {
         if (!this.sessionId) return;
         try {
-            await this.persistHistoryTurn({ notes: this.noteText });
+            await this.persistHistoryTurn({ ...this.notePayload });
         } catch (error) {
             logger.error('Failed to save notes:', error);
         }
@@ -886,7 +929,8 @@ export class SalesWizardApp extends LitElement {
                             .manualNotes=${this.manualNotes}
                             .transcripts=${this.transcripts}
                             .selectedProfile=${this.selectedProfile}
-                            @notes-change=${e => this.handleNotesChange(e)}
+                            @structured-notes-change=${e => this.handleStructuredNotesChange(e)}
+                            @manual-notes-change=${e => this.handleManualNotesChange(e)}
                             @copy-transcript=${() => this.handleCopyTranscript()}
                             @clear-session-data=${() => this.handleClearSessionData()}
                         ></side-panel>

--- a/src/utils/__tests__/renderer.sales-wizard-app.test.js
+++ b/src/utils/__tests__/renderer.sales-wizard-app.test.js
@@ -25,12 +25,19 @@ test('handleStart uses IPC bridge to persist session and switches view', async (
   assert.strictEqual(window.salesWizard.initializeGemini.mock.callCount(), 1);
   assert.strictEqual(window.salesWizard.startCapture.mock.callCount(), 1);
   assert.strictEqual(historyAddTurn.mock.callCount(), 1);
+  const persistedTurn = historyAddTurn.mock.calls[0].arguments[0];
+  assert.strictEqual(persistedTurn.sessionId, element.sessionId);
+  assert.deepStrictEqual(persistedTurn.turn, {
+    sessionStart: true,
+    notes: [],
+    manualNotes: '',
+  });
   assert.strictEqual(element.currentView, 'assistant');
 
   cleanup();
 });
 
-test('handleNotesChange saves notes through IPC bridge', async () => {
+test('handleManualNotesChange saves notes through IPC bridge', async () => {
   const { cleanup, localStorage } = setupRendererGlobals();
 
   localStorage.setItem('onboardingCompleted', '1');
@@ -47,14 +54,71 @@ test('handleNotesChange saves notes through IPC bridge', async () => {
 
   const element = new SalesWizardApp();
   element.sessionId = 'session-123';
+  element.notes = [
+    { text: 'Structured insight', type: 'auto', timestamp: 111 },
+    { text: 'Follow up question', type: 'manual', timestamp: 222 },
+  ];
 
-  await element.handleNotesChange({ detail: { value: 'Updated notes' } });
+  await element.handleManualNotesChange({ detail: { value: 'Updated notes' } });
 
   assert.strictEqual(historyAddTurn.mock.callCount(), 1);
   assert.deepStrictEqual(historyAddTurn.mock.calls[0].arguments[0], {
     sessionId: 'session-123',
-    turn: { notes: 'Updated notes' },
+    turn: {
+      notes: [
+        { text: 'Structured insight', type: 'auto', timestamp: 111 },
+        { text: 'Follow up question', type: 'manual', timestamp: 222 },
+      ],
+      manualNotes: 'Updated notes',
+    },
   });
+
+  cleanup();
+});
+
+test('handleStructuredNotesChange normalizes notes payload before persisting', async () => {
+  const { cleanup, localStorage } = setupRendererGlobals();
+
+  localStorage.setItem('onboardingCompleted', '1');
+  localStorage.setItem('apiKey', 'secret');
+
+  const historyAddTurn = mock.fn(async () => ({ success: true }));
+  window.electron.historyAddTurn = historyAddTurn;
+
+  window.salesWizard.initializeGemini = mock.fn(async () => ({}));
+  window.salesWizard.startCapture = mock.fn();
+
+  const module = await import('../../components/app/SalesWizardApp.js');
+  const SalesWizardApp = module.SalesWizardApp || customElements.get('sales-wizard-app');
+
+  const element = new SalesWizardApp();
+  element.sessionId = 'session-789';
+
+  const now = Date.now();
+  await element.handleStructuredNotesChange({
+    detail: {
+      notes: [
+        { text: '  Auto summary  ', type: '', timestamp: now },
+        { text: 'Follow up idea', timestamp: undefined },
+        null,
+        { text: '   ' },
+      ],
+    },
+  });
+
+  assert.strictEqual(historyAddTurn.mock.callCount(), 1);
+  const turnPayload = historyAddTurn.mock.calls[0].arguments[0];
+  assert.strictEqual(turnPayload.sessionId, 'session-789');
+  assert.strictEqual(turnPayload.turn.manualNotes, '');
+  assert.strictEqual(turnPayload.turn.notes.length, 2);
+  assert.deepStrictEqual(turnPayload.turn.notes[0], {
+    text: 'Auto summary',
+    type: 'auto',
+    timestamp: now,
+  });
+  assert.strictEqual(turnPayload.turn.notes[1].text, 'Follow up idea');
+  assert.strictEqual(turnPayload.turn.notes[1].type, 'auto');
+  assert.ok(typeof turnPayload.turn.notes[1].timestamp === 'number');
 
   cleanup();
 });


### PR DESCRIPTION
## Summary
- add computed getters on the renderer app to derive a normalized notes payload and legacy text representation
- persist manual and structured notes for session start, transcript turns, and direct note updates while wiring the side panel events
- update renderer tests to assert the saved history payload includes normalized structured notes alongside manual notes

## Testing
- npm run test:renderer:node *(fails: missing optional dev dependency `mock-fs` in test runner environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed641a970c8331aa1ef3e66b3c57bf