### PR TITLE
Add authenticated fetch helper for Gemini IPC endpoints

### DIFF
--- a/src/utils/gemini.js
+++ b/src/utils/gemini.js
@@ -5,6 +5,69 @@ const audioHandler = require('./audioHandler');
 const reconnection = require('./reconnection');
 const sessionManager = require('./sessionManager');
 const liveStreamManager = require('./liveStreamManager');
+const { resolveBackendOrigin } = require('../services/backendConfig.js');
+
+const API_BASE = resolveBackendOrigin();
+const AUTH_TOKEN =
+    process.env.AUTH_TOKEN || process.env.SALES_WIZARD_AUTH_TOKEN || process.env.SW_AUTH_TOKEN;
+
+async function fetchJson(url, options = {}) {
+    const { headers: originalHeaders, ...rest } = options || {};
+    const headers = new Headers(originalHeaders || {});
+
+    if (AUTH_TOKEN && !headers.has('AUTH_TOKEN')) {
+        headers.set('AUTH_TOKEN', AUTH_TOKEN);
+    }
+
+    if (!headers.has('Content-Type') && rest.body && typeof rest.body === 'string') {
+        headers.set('Content-Type', 'application/json');
+    }
+
+    const response = await fetch(url, { ...rest, headers });
+    const contentType = response.headers?.get?.('content-type') || '';
+
+    if (!response.ok) {
+        let errorPayload;
+
+        if (contentType.includes('application/json')) {
+            try {
+                errorPayload = await response.json();
+            } catch (_err) {
+                errorPayload = await response.text().catch(() => '');
+            }
+        } else {
+            errorPayload = await response.text().catch(() => '');
+        }
+
+        const message =
+            (errorPayload && typeof errorPayload === 'object' && errorPayload.error) ||
+            (typeof errorPayload === 'string' && errorPayload) ||
+            `Request failed with status ${response.status}`;
+
+        const error = new Error(message);
+        error.status = response.status;
+        error.body = errorPayload;
+        throw error;
+    }
+
+    if (response.status === 204 || response.status === 205) {
+        return null;
+    }
+
+    if (!contentType.includes('application/json')) {
+        const error = new Error('Expected JSON response');
+        error.status = response.status;
+        throw error;
+    }
+
+    try {
+        return await response.json();
+    } catch (err) {
+        const parseError = new Error('Failed to parse JSON response');
+        parseError.cause = err;
+        throw parseError;
+    }
+}
 
 function setupGeminiIpcHandlers(geminiSessionRef) {
     global.geminiSessionRef = geminiSessionRef;

--- a/tests/ipc/gemini.ipc.jest.test.js
+++ b/tests/ipc/gemini.ipc.jest.test.js
@@ -10,13 +10,19 @@ jest.mock('electron', () => {
   };
 });
 
-jest.mock('../../src/utils/audioHandler', () => ({
-  stopMacOSAudioCapture: jest.fn(),
-  startMacOSAudioCapture: jest.fn().mockResolvedValue(true),
-  killExistingSystemAudioDump: jest.fn(),
-  convertStereoToMono: jest.fn(),
-  sendAudioToGemini: jest.fn(),
-}));
+jest.mock('../../src/utils/audioHandler', () => {
+  const stopSystemAudioCapture = jest.fn();
+  const startSystemAudioCapture = jest.fn().mockResolvedValue(true);
+  return {
+    stopSystemAudioCapture,
+    startSystemAudioCapture,
+    stopMacOSAudioCapture: stopSystemAudioCapture,
+    startMacOSAudioCapture: startSystemAudioCapture,
+    killExistingSystemAudioDump: jest.fn(),
+    convertStereoToMono: jest.fn(),
+    sendAudioToGemini: jest.fn(),
+  };
+});
 
 jest.mock('../../src/utils/reconnection', () => ({
   clearSessionParams: jest.fn(),
@@ -53,7 +59,11 @@ const reconnection = require('../../src/utils/reconnection');
 const sessionManager = require('../../src/utils/sessionManager');
 const conversationStore = require('../../src/utils/conversationStore');
 
+process.env.AUTH_TOKEN = 'test-token';
+
 const { setupGeminiIpcHandlers } = require('../../src/utils/gemini');
+
+const originalFetch = global.fetch;
 
 describe('Gemini IPC handlers', () => {
   let geminiSessionRef;
@@ -63,6 +73,11 @@ describe('Gemini IPC handlers', () => {
     ipcMain.__handlers.clear();
     geminiSessionRef = { current: null };
     global.logger = { error: jest.fn(), info: jest.fn(), warn: jest.fn() };
+    process.env.AUTH_TOKEN = 'test-token';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
   });
 
   function getHandler(channel) {
@@ -103,7 +118,7 @@ describe('Gemini IPC handlers', () => {
 
     const result = await handler();
     expect(result).toEqual({ success: true });
-    expect(audioHandler.startMacOSAudioCapture).toHaveBeenCalled();
+    expect(audioHandler.startSystemAudioCapture).toHaveBeenCalled();
 
     platformSpy.mockRestore();
   });
@@ -115,7 +130,7 @@ describe('Gemini IPC handlers', () => {
 
     const result = await getHandler('close-session')();
     expect(result).toEqual({ success: true });
-    expect(audioHandler.stopMacOSAudioCapture).toHaveBeenCalled();
+    expect(audioHandler.stopSystemAudioCapture).toHaveBeenCalled();
     expect(reconnection.clearSessionParams).toHaveBeenCalled();
     expect(close).toHaveBeenCalled();
     expect(geminiSessionRef.current).toBeNull();
@@ -136,5 +151,98 @@ describe('Gemini IPC handlers', () => {
     const result = await handler();
     expect(result).toEqual({ success: true, sessionId: 'session-123' });
     expect(conversationStore.initializeNewSession).toHaveBeenCalled();
+  });
+
+  test('history:list fetches sessions via authenticated helper', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+      json: async () => [{ id: 'session-a' }],
+    };
+    global.fetch = jest.fn().mockResolvedValue(mockResponse);
+
+    setupGeminiIpcHandlers(geminiSessionRef);
+    const handler = getHandler('history:list');
+
+    const result = await handler();
+
+    expect(result).toEqual({ success: true, data: [{ id: 'session-a' }] });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url.endsWith('/history')).toBe(true);
+    const headerEntries = Object.fromEntries(options.headers.entries());
+    expect(headerEntries.AUTH_TOKEN).toBe('test-token');
+  });
+
+  test('history:set-limit sends JSON payload with auth header', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+      json: async () => ({ ok: true }),
+    };
+    global.fetch = jest.fn().mockResolvedValue(mockResponse);
+
+    setupGeminiIpcHandlers(geminiSessionRef);
+    const handler = getHandler('history:set-limit');
+
+    const result = await handler(null, 5);
+
+    expect(result).toEqual({ success: true });
+    const [, options] = global.fetch.mock.calls[0];
+    expect(options.method).toBe('PUT');
+    expect(options.body).toBe(JSON.stringify({ limit: 5 }));
+    const headerEntries = Object.fromEntries(options.headers.entries());
+    expect(headerEntries.AUTH_TOKEN).toBe('test-token');
+    expect(headerEntries['Content-Type']).toBe('application/json');
+  });
+
+  test('assistant:ask propagates backend replies', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+      json: async () => ({ reply: 'Hello there' }),
+    };
+    global.fetch = jest.fn().mockResolvedValue(mockResponse);
+
+    setupGeminiIpcHandlers(geminiSessionRef);
+    const handler = getHandler('assistant:ask');
+
+    const result = await handler(null, 'Hi!');
+
+    expect(result).toEqual({ success: true, data: { reply: 'Hello there' } });
+    const [, options] = global.fetch.mock.calls[0];
+    expect(options.method).toBe('POST');
+    expect(options.body).toBe(JSON.stringify({ prompt: 'Hi!' }));
+    const headerEntries = Object.fromEntries(options.headers.entries());
+    expect(headerEntries.AUTH_TOKEN).toBe('test-token');
+    expect(headerEntries['Content-Type']).toBe('application/json');
+  });
+
+  test('assistant:ask surfaces backend errors', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 500,
+      headers: { get: () => 'application/json' },
+      json: async () => ({ error: 'Generation failed' }),
+      text: async () => 'Generation failed',
+    };
+    global.fetch = jest.fn().mockResolvedValue(mockResponse);
+
+    setupGeminiIpcHandlers(geminiSessionRef);
+    const handler = getHandler('assistant:ask');
+
+    const result = await handler(null, 'Hello');
+
+    expect(result).toEqual({ success: false, error: 'Generation failed' });
+    expect(global.logger.error).toHaveBeenCalledWith(
+      'Error requesting assistant reply:',
+      expect.any(Error)
+    );
+    const [, options] = global.fetch.mock.calls[0];
+    const headerEntries = Object.fromEntries(options.headers.entries());
+    expect(headerEntries.AUTH_TOKEN).toBe('test-token');
   });
 });


### PR DESCRIPTION
## Summary
- derive the Gemini IPC API base from the shared backend configuration
- add an authenticated fetchJson helper for history and ask IPC handlers with robust error handling
- expand the IPC Jest suite to cover the history and assistant flows while updating audio mocks for system capture APIs

## Testing
- npm run test:backend *(fails: jest not found in PATH in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed641b3cc48331b8f0204590941ef2